### PR TITLE
Windows RT support (Arm)

### DIFF
--- a/common/clisync.h
+++ b/common/clisync.h
@@ -182,7 +182,7 @@
     return 1;
   }
 
-#elif (CLIENT_CPU == CPU_X86) || (CLIENT_CPU == CPU_AMD64) || (CLIENT_CPU == CPU_CUDA) || (CLIENT_CPU == CPU_ATI_STREAM) || (CLIENT_CPU == CPU_OPENCL)
+#elif (CLIENT_CPU == CPU_X86) || (CLIENT_CPU == CPU_AMD64) || (CLIENT_CPU == CPU_CUDA) || (CLIENT_CPU == CPU_ATI_STREAM) || (CLIENT_CPU == CPU_OPENCL) || (CLIENT_CPU == CPU_ARM)
 
   typedef volatile long fastlock_t;
 

--- a/common/core_r72.cpp
+++ b/common/core_r72.cpp
@@ -54,7 +54,8 @@ extern "C" s32 CDECL rc5_72_unit_func_snjl( RC5_72UnitWork *, u32 *, void *);
 extern "C" s32 CDECL rc5_72_unit_func_kbe( RC5_72UnitWork *, u32 *, void *);
 extern "C" s32 CDECL rc5_72_unit_func_go_2c( RC5_72UnitWork *, u32 *, void *);
 extern "C" s32 CDECL rc5_72_unit_func_go_2d( RC5_72UnitWork *, u32 *, void *);
-#elif (CLIENT_CPU == CPU_ARM)
+#elif (CLIENT_CPU == CPU_ARM) && \
+      (CLIENT_OS != OS_WIN32)
 extern "C" s32 rc5_72_unit_func_arm1( RC5_72UnitWork *, u32 *, void *);
 extern "C" s32 rc5_72_unit_func_arm2( RC5_72UnitWork *, u32 *, void *);
 extern "C" s32 rc5_72_unit_func_arm3( RC5_72UnitWork *, u32 *, void *);
@@ -736,7 +737,8 @@ int selcoreSelectCore_rc572(Client *client, unsigned int threadindex,
     switch (coresel)
     {
      /* architectures without ansi cores */
-     #if (CLIENT_CPU == CPU_ARM)
+     #if (CLIENT_CPU == CPU_ARM) && \
+         (CLIENT_OS != OS_WIN32)
       case 0:
       default:
         unit_func.gen_72 = rc5_72_unit_func_arm1;

--- a/common/cputypes.h
+++ b/common/cputypes.h
@@ -119,6 +119,8 @@
     #define CLIENT_CPU     CPU_CUDA
   #elif defined(ATI_STREAM)
     #define CLIENT_CPU     CPU_ATI_STREAM
+  #elif defined(_M_ARM)
+    #define CLIENT_CPU     CPU_ARM
   #elif defined(OPENCL)
     #define CLIENT_CPU     CPU_OPENCL
   #elif (!defined(WIN32) && !defined(__WIN32__) && !defined(_WIN32)) /* win16 */ \

--- a/makefile.vc
+++ b/makefile.vc
@@ -8,6 +8,7 @@
 #PROCESSOR_ARCHITECTURE = cuda
 #PROCESSOR_ARCHITECTURE = ATI_STREAM
 #PROCESSOR_ARCHITECTURE = OPENCL
+#PROCESSOR_ARCHITECTURE = arm
 
 BASENAME = dnetc
 OUTPUTPATH = output
@@ -65,6 +66,12 @@ OPTS_CC_CPU =
 OPTS_M_PLAT = IX86
 CHIPSRCPATH = plat
 ZIPSUFFIX = win32-x86-opencl
+!elseif "$(PROCESSOR_ARCHITECTURE)" == "arm"
+HAVE_OGR_CORES = 0
+OPTS_CC_CPU = /D_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE=1
+OPTS_M_PLAT = ARM
+CHIPSRCPATH = plat/$(PROCESSOR_ARCHITECTURE)
+ZIPSUFFIX = win32-arm
 !else
 !error unrecognized PROCESSOR_ARCHITECTURE found in the environment
 !endif
@@ -393,6 +400,13 @@ RC5_72_OBJS =                      \
         $(OUTPUTPATH)/ocl_4pipe.obj
 
 OPTS_MSVC = $(OPTS_MSVC) -DHAVE_RC5_72_CORES -DOPENCL -DDYN_TIMESLICE
+!elseif "$(PROCESSOR_ARCHITECTURE)" == "arm"
+RC5_72_OBJS =                        \
+        $(OUTPUTPATH)/r72ansi1.obj \
+        $(OUTPUTPATH)/r72ansi2.obj \
+        $(OUTPUTPATH)/r72ansi4.obj
+
+OPTS_MSVC = $(OPTS_MSVC) -DHAVE_RC5_72_CORES
 !else
 !error No RC5-72 cores for this architecture.
 !endif


### PR DESCRIPTION
Windows RT support: compiling the client for the ARM processor. Just RC5-72, just ansi cores.
Compiling for Arm: either with
1) Visual Studio Express 2012 and Windows Driver Kit 8.1 Update (driver kit needed for ARM compilers)
or 2) Visual Studio 2012 Professional