### PR TITLE
Openbsd ppc

### DIFF
--- a/common/console.cpp
+++ b/common/console.cpp
@@ -733,6 +733,7 @@ int ConGetSize(int *widthP, int *heightP) /* one-based */
         (CLIENT_OS == OS_DYNIX) || (CLIENT_OS == OS_PS2LINUX) || \
         ( (CLIENT_OS == OS_QNX) && !defined( __QNXNTO__ ) ) || \
         (CLIENT_OS == OS_SCO) || (CLIENT_OS == OS_HAIKU) || \
+        (CLIENT_OS == OS_OPENBSD) || \
         ((CLIENT_OS == OS_FREEBSD) && (__FreeBSD__ >= 8)) || \
         (CLIENT_OS == OS_IOS) || (CLIENT_OS == OS_ANDROID)
     /* good for any flavour? */
@@ -744,7 +745,7 @@ int ConGetSize(int *widthP, int *heightP) /* one-based */
       height  = winsz.ws_row;
     }
   #elif ((CLIENT_OS == OS_FREEBSD) && (__FreeBSD__ < 8)) || \
-        (CLIENT_OS == OS_BSDOS) || (CLIENT_OS == OS_OPENBSD) || \
+        (CLIENT_OS == OS_BSDOS) || \
         (CLIENT_OS == OS_NETBSD) || (CLIENT_OS == OS_DRAGONFLY)
     struct ttysize winsz;
     winsz.ts_lines = winsz.ts_cols = winsz.ts_xxx = winsz.ts_yyy = 0;

--- a/configure
+++ b/configure
@@ -2481,7 +2481,7 @@ case "$1" in
         TARGET_CC="g++"
         generate_gcc_opts "ppc" "openbsd"
         TARGET_CCFLAGS="$OPTS_GCC"
-        #TARGET_LDFLAGS="-static"
+        TARGET_LDFLAGS="-static"
         TARGET_LIBS="-ltermcap"
         TARGET_DOCFILES="docs/readme._ix"   
         TARGET_TARBALL="openbsd-ppc"

--- a/configure
+++ b/configure
@@ -432,8 +432,12 @@ add_sources() # $1=os, $2=arch, $3=custom
         TARGET_ADDASMS="$TARGET_ADDASMS rc5-72/ppc/r72-ppc-mh-2.gas.s \
                                         rc5-72/ppc/r72-603e-mh-1-addi.gas.s \
                                         rc5-72/ppc/r72-604e-mh-1-addi.gas.s \
-                                        rc5-72/ppc/r72-KKS2pipes.gas.s \
-                                        rc5-72/ppc/r72-KKS604e.gas.s"
+                                        rc5-72/ppc/r72-KKS2pipes.gas.s"
+        if [ "$1" = "openbsd" ]; then
+          TARGET_ADDASMS="$TARGET_ADDASMS rc5-72/ppc/r72-KKS604e.gas2.s"
+        else
+          TARGET_ADDASMS="$TARGET_ADDASMS rc5-72/ppc/r72-KKS604e.gas.s"
+        fi
 
         if [ "X$3" = "Xaltivec" ] ; then
           TARGET_ADDASMS="$TARGET_ADDASMS rc5-72/ppc/r72-KKS7400.gas.s \
@@ -459,7 +463,11 @@ add_sources() # $1=os, $2=arch, $3=custom
       if [ "$1" = "aix" ]; then
         TARGET_ADDASMS="$TARGET_ADDASMS $OGR/ppc/FLEGE_scalar.toc.s"
       else
-        TARGET_ADDASMS="$TARGET_ADDASMS $OGR/ppc/FLEGE_scalar.gas.s"
+        if [ "$1" = "openbsd" ]; then
+          TARGET_ADDASMS="$TARGET_ADDASMS $OGR/ppc/FLEGE_scalar.gas2.s"
+        else
+          TARGET_ADDASMS="$TARGET_ADDASMS $OGR/ppc/FLEGE_scalar.gas.s"
+        fi
         if [ "X$3" = "Xaltivec" ]; then
           TARGET_ADDASMS="$TARGET_ADDASMS $OGR/ppc/FLEGE_hybrid.gas.s"
         fi
@@ -2473,7 +2481,7 @@ case "$1" in
         TARGET_CC="g++"
         generate_gcc_opts "ppc" "openbsd"
         TARGET_CCFLAGS="$OPTS_GCC"
-        TARGET_LDFLAGS="-static"
+        #TARGET_LDFLAGS="-static"
         TARGET_LIBS="-ltermcap"
         TARGET_DOCFILES="docs/readme._ix"   
         TARGET_TARBALL="openbsd-ppc"

--- a/ogr/ppc/FLEGE_scalar.gas2.s
+++ b/ogr/ppc/FLEGE_scalar.gas2.s
@@ -173,11 +173,10 @@ cycle_ppc_scalar_256:
     ;#addi     r2,r2,(L_SwitchCase-128)@l
     ;mflr     r0
     ;bl       lblAA
-    ;.long L_SwitchCase-128
     ;lblAA:
     ;mflr     r2
     ;mtlr     r0
-    ;lwz      r2,0(r2)
+    ;addi     r2,r2,L_SwitchCase-lblAA-128
     ;.if      0                         ;# Skip over AS code
     lis       r2,ha16(L_SwitchCase-128)
     addi      r2,r2,lo16(L_SwitchCase-128)

--- a/ogr/ppc/FLEGE_scalar.gas2.s
+++ b/ogr/ppc/FLEGE_scalar.gas2.s
@@ -172,7 +172,7 @@ cycle_ppc_scalar_256:
     ;#lis      r2,(L_SwitchCase-128)@ha
     ;#addi     r2,r2,(L_SwitchCase-128)@l
     ;mflr     r0
-    ;bl       lblAA
+    ;bcl      20,31,lblAA	# see PowerPC PEM32b doc
     ;lblAA:
     ;mflr     r2
     ;mtlr     r0

--- a/ogr/ppc/FLEGE_scalar.gas2.s
+++ b/ogr/ppc/FLEGE_scalar.gas2.s
@@ -1,0 +1,1510 @@
+;#
+;# Copyright distributed.net 1999-2008 - All Rights Reserved
+;# For use in distributed.net projects only.
+;# Any other distribution or use of this source violates copyright.
+;#
+;# PPC Scalar core - 256 bits OGR core for PowerPC processors.
+;# Code designed for G3 (MPC750)
+;# Written by Didier Levet <kakace@distributed.net>
+;#
+;# $Id: FLEGE_scalar.gas.s,v 1.3 2009/05/08 16:32:52 kakace Exp $
+;#
+;#============================================================================
+;# Special notes :
+;# - The code extensively use simplified mnemonics.
+;# - Use a custom stack frame (leaf procedure).
+;# - LR register not used nor saved in caller's stack.
+;# - CTR, CR0, CR1, CR7, GPR0 and GPR3-GPR12 are volatile (not preserved).
+;#
+;#============================================================================
+
+
+    .text     
+    .align    4
+    .globl    _cycle_ppc_scalar_256     ;# a.out
+    .globl    cycle_ppc_scalar_256      ;# elf
+
+
+;# OrgNgLevel dependencies (offsets)
+.set          Levels_list,        0     ;# list bitmap
+.set          Levels_dist,        32    ;# dist bitmap
+.set          Levels_comp,        64    ;# comp bitmap
+.set          mark,               96
+.set          limit,              100
+.set          SIZEOF_LEVEL,       104
+.set          NextLev_dist,       Levels_dist+SIZEOF_LEVEL ;# dist bitmap (next level)
+
+
+;# OgrNgState dependencies (offsets)
+.set          MaxLength,          0     ;# oState->max
+.set          MaxDepth,           8     ;# oState->maxdepthm1
+.set          MidSegA,            12    ;# oState->half_depth
+.set          MidSegB,            16    ;# oState->half_depth2
+.set          StopDepth,          24    ;# oState->stopdepth
+.set          Depth,              28    ;# oState->depth
+.set          Levels,             32    ;# oState->Levels[]
+
+
+;# rlwinm arguments
+.set          CHOOSE_BITS,        16
+.set          SH,                 CHOOSE_BITS+6
+.set          MB,                 32-CHOOSE_BITS-6
+.set          ME,                 31-6
+
+
+;#============================================================================
+;# Custom stack frame
+
+.set          FIRST_NV_GPR, 13          ;# Save r13..r31
+.set          GPRSaveArea, (32-FIRST_NV_GPR) * 4
+
+.set          localTop, 48
+
+.set          oState, 16                ;# struct OgrNgState*
+.set          pNodes, 20                ;# int* pNodes
+.set          gpr2, 24
+.set          maxLenM1, 28              ;# oState->max - 1
+.set          pLevelA, 32               ;# &Levels[half_depth]
+.set          FrameSize, (localTop + GPRSaveArea + 15) & (-16)
+
+;#============================================================================
+;# Register aliases (GAS). Ignored by Apple's AS
+
+;.set         r0,0
+;.set         r1,1
+;.set         r2,2
+;.set         r3,3
+;.set         r4,4
+;.set         r5,5
+;.set         r6,6
+;.set         r7,7
+;.set         r8,8
+;.set         r9,9
+;.set         r10,10
+;.set         r11,11
+;.set         r12,12
+;.set         r13,13
+;.set         r14,14
+;.set         r15,15
+;.set         r16,16
+;.set         r17,17
+;.set         r18,18
+;.set         r19,19
+;.set         r20,20
+;.set         r21,21
+;.set         r22,22
+;.set         r23,23
+;.set         r24,24
+;.set         r25,25
+;.set         r26,26
+;.set         r27,27
+;.set         r28,28
+;.set         r29,29
+;.set         r30,30
+;.set         r31,31
+
+
+;#============================================================================
+;# int cycle_ppc_scalar_256(struct OgrNgState* oState (r3)
+;#                          int*               pNodes (r4)
+;#                          const u16*         pChoose (r5)
+
+_cycle_ppc_scalar_256:
+cycle_ppc_scalar_256:
+    mr        r10,r1                    ;# Caller's stack pointer
+    clrlwi    r12,r1,27                 ;# keep the low-order 4 bits
+    subfic    r12,r12,-FrameSize        ;# Frame size, including padding
+    stwux     r1,r1,r12
+
+    ;# Save non-volatile registers
+    stmw      r13,-GPRSaveArea(r10)     ;# Save GPRs
+
+
+;#============================================================================
+;# Core engine initialization - Registers allocation :
+;#   r0  := c0neg or temp3
+;#   r2  := JumpTable (const)
+;#   r3  := level
+;#   r4  := nodes
+;#   r5  := const u16* pChoose[]
+;#   r6  := Depth
+;#   r7  := mark
+;#   r8  := limit
+;#   r9  := half_depth (const)
+;#   r10 := half_depth2 (const)
+;#   r11 := stopdepth (const)
+;#   r12 := maxdepthm1 (const)
+;#   r13 := dist0 or newbit
+;#   r14 := temp1
+;#   r15 := temp2
+;#   r16 := list0
+;#   r17 := list1
+;#   r18 := list2
+;#   r19 := list3
+;#   r20 := list4
+;#   r21 := list5
+;#   r22 := list6
+;#   r23 := list7
+;#   r24 := comp0
+;#   r25 := comp1
+;#   r26 := comp2
+;#   r27 := comp3
+;#   r28 := comp4
+;#   r29 := comp5
+;#   r30 := comp6
+;#   r31 := comp7
+
+    ;# Initialize local variables.
+    stw       r3,oState(r1)             ;# store oState
+    stw       r4,pNodes(r1)             ;# store pNodes
+    stw       r2,gpr2(r1)               ;# store GPR2
+    lwz       r9,MidSegA(r3)            ;# oState->half_depth
+    lwz       r10,MidSegB(r3)           ;# oState->half_depth2
+    lwz       r23,MaxLength(r3)         ;# oState->max
+    lwz       r6,Depth(r3)              ;# oState->depth
+    lwz       r11,StopDepth(r3)         ;# oState->stopdepth
+    lwz       r12,MaxDepth(r3)          ;# oState->maxdepthm1
+    lwz       r4,0(r4)                  ;# Load nodes count
+    subi      r23,r23,1                 ;# max -= 1
+    stw       r23,maxLenM1(r1)
+
+    ;# Dirty trick to cope with GAS vs AS syntax.
+    ;#lis      r2,(L_SwitchCase-128)@ha
+    ;#addi     r2,r2,(L_SwitchCase-128)@l
+    ;mflr     r0
+    ;bl       lblAA
+    ;.long L_SwitchCase-128
+    ;lblAA:
+    ;mflr     r2
+    ;mtlr     r0
+    ;lwz      r2,0(r2)
+    ;.if      0                         ;# Skip over AS code
+    lis       r2,ha16(L_SwitchCase-128)
+    addi      r2,r2,lo16(L_SwitchCase-128)
+    ;.endif   
+
+    ;# Compute the base pointer to access pre-computed limits
+    ;# This pointer always points to pChoose[0][Depth]
+    add       r14,r6,r6                 ;# = depth * 2
+    add       r5,r5,r14                 ;# &pChoose[0][Depth]
+
+    ;# Compute the pointer to Levels[half_depth]
+    mulli     r14,r9,SIZEOF_LEVEL       ;# half_depth * SIZEOF_LEVEL
+    add       r14,r3,r14                ;# + oState
+    addi      r14,r14,Levels            ;# + Levels = &Levels[half_depth]
+    stw       r14,pLevelA(r1)
+
+    ;# Compute the pointer to Levels[Depth]
+    mulli     r14,r6,SIZEOF_LEVEL       ;# Depth * SIZEOF_LEVEL
+    add       r14,r14,r3                ;# + oState
+    addi      r3,r14,Levels             ;# + Levels = &Levels[Depth]
+
+    cmpw      r6,r12                    ;# Depth == MaxDepth ?
+
+    ;# Load state.
+    lwz       r7,mark(r3)               ;# Levels[Depth].mark
+    lwz       r8,limit(r3)              ;# Levels[Depth].limit
+    lwz       r16,Levels_list+0(r3)     ;# list[0]
+    lwz       r17,Levels_list+4(r3)     ;# list[1]
+    lwz       r18,Levels_list+8(r3)     ;# list[2]
+    lwz       r19,Levels_list+12(r3)    ;# list[3]
+    lwz       r20,Levels_list+16(r3)    ;# list[4]
+    lwz       r21,Levels_list+20(r3)    ;# list[5]
+    lwz       r22,Levels_list+24(r3)    ;# list[6]
+    lwz       r23,Levels_list+28(r3)    ;# list[7]
+    lwz       r24,Levels_comp+0(r3)     ;# comp[0]
+    lwz       r25,Levels_comp+4(r3)     ;# comp[1]
+    lwz       r26,Levels_comp+8(r3)     ;# comp[2]
+    lwz       r27,Levels_comp+12(r3)    ;# comp[3]
+    lwz       r28,Levels_comp+16(r3)    ;# comp[4]
+    lwz       r29,Levels_comp+20(r3)    ;# comp[5]
+    lwz       r30,Levels_comp+24(r3)    ;# comp[6]
+    lwz       r31,Levels_comp+28(r3)    ;# comp[7]
+    li        r13,0                     ;# newbit = 0
+    not       r0,r24                    ;# ~comp0
+    srwi      r0,r0,1                   ;# (~comp0) >> 1
+    beq       L_MainLoop                ;# Depth == MaxDepth
+
+    li        r13,1                     ;# newbit = 1
+    b         L_MainLoop
+
+
+;#============================================================================
+
+    .align    4
+    nop       
+
+L_UpLevel:
+    ;# Backtrack to the preceeding level.
+    ;# r3  := pLevel
+    ;# r6  := depth
+    ;# r11 := stopdepth
+    ;# r10 := half_depth2 = MidSegB
+    ;# r5  := pChoose
+    subi      r3,r3,SIZEOF_LEVEL        ;# --Levels
+    subi      r6,r6,1                   ;# --Depth
+    lwz       r24,Levels_comp(r3)       ;# comp0
+    cmpw      r6,r11                    ;# Depth > StopDepth
+    lwz       r8,limit(r3)              ;# limit = Levels[Depth].limit
+    subi      r5,r5,2                   ;# --pChoose
+    lwz       r7,mark(r3)               ;# mark = Levels[Depth].mark
+    not       r0,r24                    ;# c0neg = ~comp0
+    lwz       r16,Levels_list+0(r3)     ;# list[0]
+    lwz       r17,Levels_list+4(r3)     ;# list[1]
+    lwz       r18,Levels_list+8(r3)     ;# list[2]
+    lwz       r19,Levels_list+12(r3)    ;# list[3]
+    lwz       r20,Levels_list+16(r3)    ;# list[4]
+    lwz       r21,Levels_list+20(r3)    ;# list[5]
+    lwz       r22,Levels_list+24(r3)    ;# list[6]
+    lwz       r23,Levels_list+28(r3)    ;# list[7]
+    srwi      r0,r0,1                   ;# c0neg = (~comp0) >> 1
+    lwz       r25,Levels_comp+4(r3)     ;# comp[1]
+    lwz       r26,Levels_comp+8(r3)     ;# comp[2]
+    lwz       r27,Levels_comp+12(r3)    ;# comp[3]
+    lwz       r28,Levels_comp+16(r3)    ;# comp[4]
+    lwz       r29,Levels_comp+20(r3)    ;# comp[5]
+    lwz       r30,Levels_comp+24(r3)    ;# comp[6]
+    lwz       r31,Levels_comp+28(r3)    ;# comp[7]
+    li        r13,0                     ;# newbit = 0
+    ble-      L_exit                    ;# Depth <= StopDepth
+
+L_MainLoop:
+    ;#  r0  := (~comp0) >> 1
+    ;#  r8  := limit
+    ;#  r7  := mark
+    ;#  r24 := comp0
+    ;#  r2  := JumpTable
+    ;#  r13 := newbit
+    cntlzw    r14,r0                    ;# diff
+    cmpwi     cr1,r24,-1                ;# comp0 == 0xFFFFFFFF ?
+    add       r7,r7,r14                 ;# mark += diff
+    slwi      r15,r14,7                 ;# = offset to the corresponding 'case' block
+    cmpw      r7,r8                     ;# mark > limit ?
+    add       r15,r2,r15                ;# 'case' address
+    bgt-      L_UpLevel                 ;# Go back to preceding mark.
+    mtctr     r15
+    cmpw      r6,r12                    ;# depth == maxdepthm1 ?
+    rotlw     r24,r24,r14               ;# rotate comp0
+    bctr                                ;# Go shift the bitmaps
+
+    .align    4
+L_SwitchCase:
+    ;# Shift bitmaps by 'diff' bits.
+    ;# r14 := diff
+    ;# cr0 := depth == maxdepthm1
+    ;# cr1 := comp0 == 0xFFFFFFFF
+    ;# diff == 1
+    rotlwi    r25,r25,1                 ;# rotate comp1
+    rotlwi    r26,r26,1                 ;# rotate comp2
+    rotlwi    r27,r27,1                 ;# rotate comp3
+    rotlwi    r28,r28,1                 ;# rotate comp4
+    rotlwi    r29,r29,1                 ;# rotate comp5
+    rotlwi    r30,r30,1                 ;# rotate comp6
+    rotrwi    r16,r16,1                 ;# rotate list0
+    rotrwi    r17,r17,1                 ;# rotate list1
+    rotrwi    r18,r18,1                 ;# rotate list2
+    rotrwi    r19,r19,1                 ;# rotate list3
+    rotrwi    r20,r20,1                 ;# rotate list4
+    rotrwi    r21,r21,1                 ;# rotate list5
+    rotrwi    r22,r22,1                 ;# rotate list6
+    rotrwi    r23,r23,1                 ;# rotate list7
+    rlwimi    r24,r25,0,31,31           ;# comp0 = comp0:comp1 << 1
+    rlwimi    r25,r26,0,31,31           ;# comp1 = comp1:comp2 << 1
+    rlwimi    r26,r27,0,31,31           ;# comp2 = comp2:comp3 << 1
+    rlwimi    r27,r28,0,31,31           ;# comp3 = comp3:comp4 << 1
+    rlwimi    r28,r29,0,31,31           ;# comp4 = comp4:comp5 << 1
+    rlwimi    r29,r30,0,31,31           ;# comp5 = comp5:comp6 << 1
+    rlwimi    r30,r31,1,31,31           ;# comp6 = comp6:comp7 << 1
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,0             ;# list7 = list6:list7 >> 1
+    rlwimi    r22,r21,0,0,0             ;# list6 = list5:list6 >> 1
+    rlwimi    r21,r20,0,0,0             ;# list5 = list4:list5 >> 1
+    rlwimi    r20,r19,0,0,0             ;# list4 = list3:list4 >> 1
+    rlwimi    r19,r18,0,0,0             ;# list3 = list2:list3 >> 1
+    rlwimi    r18,r17,0,0,0             ;# list2 = list1:list2 >> 1
+    rlwimi    r17,r16,0,0,0             ;# list1 = list0:list1 >> 1
+    rlwimi    r16,r13,31,0,0            ;# list0 = newbit:list0 >> 1
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 2
+    rotlwi    r25,r25,2                 ;# rotate comp1
+    rotlwi    r26,r26,2                 ;# rotate comp2
+    rotlwi    r27,r27,2                 ;# rotate comp3
+    rotlwi    r28,r28,2                 ;# rotate comp4
+    rotlwi    r29,r29,2                 ;# rotate comp5
+    rotlwi    r30,r30,2                 ;# rotate comp6
+    rotrwi    r16,r16,2                 ;# rotate list0
+    rotrwi    r17,r17,2                 ;# rotate list1
+    rotrwi    r18,r18,2                 ;# rotate list2
+    rotrwi    r19,r19,2                 ;# rotate list3
+    rotrwi    r20,r20,2                 ;# rotate list4
+    rotrwi    r21,r21,2                 ;# rotate list5
+    rotrwi    r22,r22,2                 ;# rotate list6
+    rotrwi    r23,r23,2                 ;# rotate list7
+    rlwimi    r24,r25,0,30,31           ;# comp0 = comp0:comp1 << 2
+    rlwimi    r25,r26,0,30,31           ;# comp1 = comp1:comp2 << 2
+    rlwimi    r26,r27,0,30,31           ;# comp2 = comp2:comp3 << 2
+    rlwimi    r27,r28,0,30,31           ;# comp3 = comp3:comp4 << 2
+    rlwimi    r28,r29,0,30,31           ;# comp4 = comp4:comp5 << 2
+    rlwimi    r29,r30,0,30,31           ;# comp5 = comp5:comp6 << 2
+    rlwimi    r30,r31,2,30,31           ;# comp6 = comp6:comp7 << 2
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,1             ;# list7 = list6:list7 >> 2
+    rlwimi    r22,r21,0,0,1             ;# list6 = list5:list6 >> 2
+    rlwimi    r21,r20,0,0,1             ;# list5 = list4:list5 >> 2
+    rlwimi    r20,r19,0,0,1             ;# list4 = list3:list4 >> 2
+    rlwimi    r19,r18,0,0,1             ;# list3 = list2:list3 >> 2
+    rlwimi    r18,r17,0,0,1             ;# list2 = list1:list2 >> 2
+    rlwimi    r17,r16,0,0,1             ;# list1 = list0:list1 >> 2
+    rlwimi    r16,r13,30,0,1            ;# list0 = newbit:list0 >> 2
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 3
+    rotlwi    r25,r25,3                 ;# rotate comp1
+    rotlwi    r26,r26,3                 ;# rotate comp2
+    rotlwi    r27,r27,3                 ;# rotate comp3
+    rotlwi    r28,r28,3                 ;# rotate comp4
+    rotlwi    r29,r29,3                 ;# rotate comp5
+    rotlwi    r30,r30,3                 ;# rotate comp6
+    rotrwi    r16,r16,3                 ;# rotate list0
+    rotrwi    r17,r17,3                 ;# rotate list1
+    rotrwi    r18,r18,3                 ;# rotate list2
+    rotrwi    r19,r19,3                 ;# rotate list3
+    rotrwi    r20,r20,3                 ;# rotate list4
+    rotrwi    r21,r21,3                 ;# rotate list5
+    rotrwi    r22,r22,3                 ;# rotate list6
+    rotrwi    r23,r23,3                 ;# rotate list7
+    rlwimi    r24,r25,0,29,31           ;# comp0 = comp0:comp1 << 3
+    rlwimi    r25,r26,0,29,31           ;# comp1 = comp1:comp2 << 3
+    rlwimi    r26,r27,0,29,31           ;# comp2 = comp2:comp3 << 3
+    rlwimi    r27,r28,0,29,31           ;# comp3 = comp3:comp4 << 3
+    rlwimi    r28,r29,0,29,31           ;# comp4 = comp4:comp5 << 3
+    rlwimi    r29,r30,0,29,31           ;# comp5 = comp5:comp6 << 3
+    rlwimi    r30,r31,3,29,31           ;# comp6 = comp6:comp7 << 3
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,2             ;# list7 = list6:list7 >> 3
+    rlwimi    r22,r21,0,0,2             ;# list6 = list5:list6 >> 3
+    rlwimi    r21,r20,0,0,2             ;# list5 = list4:list5 >> 3
+    rlwimi    r20,r19,0,0,2             ;# list4 = list3:list4 >> 3
+    rlwimi    r19,r18,0,0,2             ;# list3 = list2:list3 >> 3
+    rlwimi    r18,r17,0,0,2             ;# list2 = list1:list2 >> 3
+    rlwimi    r17,r16,0,0,2             ;# list1 = list0:list1 >> 3
+    rlwimi    r16,r13,29,0,2            ;# list0 = newbit:list0 >> 3
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 4
+    rotlwi    r25,r25,4                 ;# rotate comp1
+    rotlwi    r26,r26,4                 ;# rotate comp2
+    rotlwi    r27,r27,4                 ;# rotate comp3
+    rotlwi    r28,r28,4                 ;# rotate comp4
+    rotlwi    r29,r29,4                 ;# rotate comp5
+    rotlwi    r30,r30,4                 ;# rotate comp6
+    rotrwi    r16,r16,4                 ;# rotate list0
+    rotrwi    r17,r17,4                 ;# rotate list1
+    rotrwi    r18,r18,4                 ;# rotate list2
+    rotrwi    r19,r19,4                 ;# rotate list3
+    rotrwi    r20,r20,4                 ;# rotate list4
+    rotrwi    r21,r21,4                 ;# rotate list5
+    rotrwi    r22,r22,4                 ;# rotate list6
+    rotrwi    r23,r23,4                 ;# rotate list7
+    rlwimi    r24,r25,0,28,31           ;# comp0 = comp0:comp1 << 4
+    rlwimi    r25,r26,0,28,31           ;# comp1 = comp1:comp2 << 4
+    rlwimi    r26,r27,0,28,31           ;# comp2 = comp2:comp3 << 4
+    rlwimi    r27,r28,0,28,31           ;# comp3 = comp3:comp4 << 4
+    rlwimi    r28,r29,0,28,31           ;# comp4 = comp4:comp5 << 4
+    rlwimi    r29,r30,0,28,31           ;# comp5 = comp5:comp6 << 4
+    rlwimi    r30,r31,4,28,31           ;# comp6 = comp6:comp7 << 4
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,3             ;# list7 = list6:list7 >> 4
+    rlwimi    r22,r21,0,0,3             ;# list6 = list5:list6 >> 4
+    rlwimi    r21,r20,0,0,3             ;# list5 = list4:list5 >> 4
+    rlwimi    r20,r19,0,0,3             ;# list4 = list3:list4 >> 4
+    rlwimi    r19,r18,0,0,3             ;# list3 = list2:list3 >> 4
+    rlwimi    r18,r17,0,0,3             ;# list2 = list1:list2 >> 4
+    rlwimi    r17,r16,0,0,3             ;# list1 = list0:list1 >> 4
+    rlwimi    r16,r13,28,0,3            ;# list0 = newbit:list0 >> 4
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 5
+    rotlwi    r25,r25,5                 ;# rotate comp1
+    rotlwi    r26,r26,5                 ;# rotate comp2
+    rotlwi    r27,r27,5                 ;# rotate comp3
+    rotlwi    r28,r28,5                 ;# rotate comp4
+    rotlwi    r29,r29,5                 ;# rotate comp5
+    rotlwi    r30,r30,5                 ;# rotate comp6
+    rotrwi    r16,r16,5                 ;# rotate list0
+    rotrwi    r17,r17,5                 ;# rotate list1
+    rotrwi    r18,r18,5                 ;# rotate list2
+    rotrwi    r19,r19,5                 ;# rotate list3
+    rotrwi    r20,r20,5                 ;# rotate list4
+    rotrwi    r21,r21,5                 ;# rotate list5
+    rotrwi    r22,r22,5                 ;# rotate list6
+    rotrwi    r23,r23,5                 ;# rotate list7
+    rlwimi    r24,r25,0,27,31           ;# comp0 = comp0:comp1 << 5
+    rlwimi    r25,r26,0,27,31           ;# comp1 = comp1:comp2 << 5
+    rlwimi    r26,r27,0,27,31           ;# comp2 = comp2:comp3 << 5
+    rlwimi    r27,r28,0,27,31           ;# comp3 = comp3:comp4 << 5
+    rlwimi    r28,r29,0,27,31           ;# comp4 = comp4:comp5 << 5
+    rlwimi    r29,r30,0,27,31           ;# comp5 = comp5:comp6 << 5
+    rlwimi    r30,r31,5,27,31           ;# comp6 = comp6:comp7 << 5
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,4             ;# list7 = list6:list7 >> 5
+    rlwimi    r22,r21,0,0,4             ;# list6 = list5:list6 >> 5
+    rlwimi    r21,r20,0,0,4             ;# list5 = list4:list5 >> 5
+    rlwimi    r20,r19,0,0,4             ;# list4 = list3:list4 >> 5
+    rlwimi    r19,r18,0,0,4             ;# list3 = list2:list3 >> 5
+    rlwimi    r18,r17,0,0,4             ;# list2 = list1:list2 >> 5
+    rlwimi    r17,r16,0,0,4             ;# list1 = list0:list1 >> 5
+    rlwimi    r16,r13,27,0,4            ;# list0 = newbit:list0 >> 5
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 6
+    rotlwi    r25,r25,6                 ;# rotate comp1
+    rotlwi    r26,r26,6                 ;# rotate comp2
+    rotlwi    r27,r27,6                 ;# rotate comp3
+    rotlwi    r28,r28,6                 ;# rotate comp4
+    rotlwi    r29,r29,6                 ;# rotate comp5
+    rotlwi    r30,r30,6                 ;# rotate comp6
+    rotrwi    r16,r16,6                 ;# rotate list0
+    rotrwi    r17,r17,6                 ;# rotate list1
+    rotrwi    r18,r18,6                 ;# rotate list2
+    rotrwi    r19,r19,6                 ;# rotate list3
+    rotrwi    r20,r20,6                 ;# rotate list4
+    rotrwi    r21,r21,6                 ;# rotate list5
+    rotrwi    r22,r22,6                 ;# rotate list6
+    rotrwi    r23,r23,6                 ;# rotate list7
+    rlwimi    r24,r25,0,26,31           ;# comp0 = comp0:comp1 << 6
+    rlwimi    r25,r26,0,26,31           ;# comp1 = comp1:comp2 << 6
+    rlwimi    r26,r27,0,26,31           ;# comp2 = comp2:comp3 << 6
+    rlwimi    r27,r28,0,26,31           ;# comp3 = comp3:comp4 << 6
+    rlwimi    r28,r29,0,26,31           ;# comp4 = comp4:comp5 << 6
+    rlwimi    r29,r30,0,26,31           ;# comp5 = comp5:comp6 << 6
+    rlwimi    r30,r31,6,26,31           ;# comp6 = comp6:comp7 << 6
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,5             ;# list7 = list6:list7 >> 6
+    rlwimi    r22,r21,0,0,5             ;# list6 = list5:list6 >> 6
+    rlwimi    r21,r20,0,0,5             ;# list5 = list4:list5 >> 6
+    rlwimi    r20,r19,0,0,5             ;# list4 = list3:list4 >> 6
+    rlwimi    r19,r18,0,0,5             ;# list3 = list2:list3 >> 6
+    rlwimi    r18,r17,0,0,5             ;# list2 = list1:list2 >> 6
+    rlwimi    r17,r16,0,0,5             ;# list1 = list0:list1 >> 6
+    rlwimi    r16,r13,26,0,5            ;# list0 = newbit:list0 >> 6
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 7
+    rotlwi    r25,r25,7                 ;# rotate comp1
+    rotlwi    r26,r26,7                 ;# rotate comp2
+    rotlwi    r27,r27,7                 ;# rotate comp3
+    rotlwi    r28,r28,7                 ;# rotate comp4
+    rotlwi    r29,r29,7                 ;# rotate comp5
+    rotlwi    r30,r30,7                 ;# rotate comp6
+    rotrwi    r16,r16,7                 ;# rotate list0
+    rotrwi    r17,r17,7                 ;# rotate list1
+    rotrwi    r18,r18,7                 ;# rotate list2
+    rotrwi    r19,r19,7                 ;# rotate list3
+    rotrwi    r20,r20,7                 ;# rotate list4
+    rotrwi    r21,r21,7                 ;# rotate list5
+    rotrwi    r22,r22,7                 ;# rotate list6
+    rotrwi    r23,r23,7                 ;# rotate list7
+    rlwimi    r24,r25,0,25,31           ;# comp0 = comp0:comp1 << 7
+    rlwimi    r25,r26,0,25,31           ;# comp1 = comp1:comp2 << 7
+    rlwimi    r26,r27,0,25,31           ;# comp2 = comp2:comp3 << 7
+    rlwimi    r27,r28,0,25,31           ;# comp3 = comp3:comp4 << 7
+    rlwimi    r28,r29,0,25,31           ;# comp4 = comp4:comp5 << 7
+    rlwimi    r29,r30,0,25,31           ;# comp5 = comp5:comp6 << 7
+    rlwimi    r30,r31,7,25,31           ;# comp6 = comp6:comp7 << 7
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,6             ;# list7 = list6:list7 >> 7
+    rlwimi    r22,r21,0,0,6             ;# list6 = list5:list6 >> 7
+    rlwimi    r21,r20,0,0,6             ;# list5 = list4:list5 >> 7
+    rlwimi    r20,r19,0,0,6             ;# list4 = list3:list4 >> 7
+    rlwimi    r19,r18,0,0,6             ;# list3 = list2:list3 >> 7
+    rlwimi    r18,r17,0,0,6             ;# list2 = list1:list2 >> 7
+    rlwimi    r17,r16,0,0,6             ;# list1 = list0:list1 >> 7
+    rlwimi    r16,r13,25,0,6            ;# list0 = newbit:list0 >> 7
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 8
+    rotlwi    r25,r25,8                 ;# rotate comp1
+    rotlwi    r26,r26,8                 ;# rotate comp2
+    rotlwi    r27,r27,8                 ;# rotate comp3
+    rotlwi    r28,r28,8                 ;# rotate comp4
+    rotlwi    r29,r29,8                 ;# rotate comp5
+    rotlwi    r30,r30,8                 ;# rotate comp6
+    rotrwi    r16,r16,8                 ;# rotate list0
+    rotrwi    r17,r17,8                 ;# rotate list1
+    rotrwi    r18,r18,8                 ;# rotate list2
+    rotrwi    r19,r19,8                 ;# rotate list3
+    rotrwi    r20,r20,8                 ;# rotate list4
+    rotrwi    r21,r21,8                 ;# rotate list5
+    rotrwi    r22,r22,8                 ;# rotate list6
+    rotrwi    r23,r23,8                 ;# rotate list7
+    rlwimi    r24,r25,0,24,31           ;# comp0 = comp0:comp1 << 8
+    rlwimi    r25,r26,0,24,31           ;# comp1 = comp1:comp2 << 8
+    rlwimi    r26,r27,0,24,31           ;# comp2 = comp2:comp3 << 8
+    rlwimi    r27,r28,0,24,31           ;# comp3 = comp3:comp4 << 8
+    rlwimi    r28,r29,0,24,31           ;# comp4 = comp4:comp5 << 8
+    rlwimi    r29,r30,0,24,31           ;# comp5 = comp5:comp6 << 8
+    rlwimi    r30,r31,8,24,31           ;# comp6 = comp6:comp7 << 8
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,7             ;# list7 = list6:list7 >> 8
+    rlwimi    r22,r21,0,0,7             ;# list6 = list5:list6 >> 8
+    rlwimi    r21,r20,0,0,7             ;# list5 = list4:list5 >> 8
+    rlwimi    r20,r19,0,0,7             ;# list4 = list3:list4 >> 8
+    rlwimi    r19,r18,0,0,7             ;# list3 = list2:list3 >> 8
+    rlwimi    r18,r17,0,0,7             ;# list2 = list1:list2 >> 8
+    rlwimi    r17,r16,0,0,7             ;# list1 = list0:list1 >> 8
+    rlwimi    r16,r13,24,0,7            ;# list0 = newbit:list0 >> 8
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 9
+    rotlwi    r25,r25,9                 ;# rotate comp1
+    rotlwi    r26,r26,9                 ;# rotate comp2
+    rotlwi    r27,r27,9                 ;# rotate comp3
+    rotlwi    r28,r28,9                 ;# rotate comp4
+    rotlwi    r29,r29,9                 ;# rotate comp5
+    rotlwi    r30,r30,9                 ;# rotate comp6
+    rotrwi    r16,r16,9                 ;# rotate list0
+    rotrwi    r17,r17,9                 ;# rotate list1
+    rotrwi    r18,r18,9                 ;# rotate list2
+    rotrwi    r19,r19,9                 ;# rotate list3
+    rotrwi    r20,r20,9                 ;# rotate list4
+    rotrwi    r21,r21,9                 ;# rotate list5
+    rotrwi    r22,r22,9                 ;# rotate list6
+    rotrwi    r23,r23,9                 ;# rotate list7
+    rlwimi    r24,r25,0,23,31           ;# comp0 = comp0:comp1 << 9
+    rlwimi    r25,r26,0,23,31           ;# comp1 = comp1:comp2 << 9
+    rlwimi    r26,r27,0,23,31           ;# comp2 = comp2:comp3 << 9
+    rlwimi    r27,r28,0,23,31           ;# comp3 = comp3:comp4 << 9
+    rlwimi    r28,r29,0,23,31           ;# comp4 = comp4:comp5 << 9
+    rlwimi    r29,r30,0,23,31           ;# comp5 = comp5:comp6 << 9
+    rlwimi    r30,r31,9,23,31           ;# comp6 = comp6:comp7 << 9
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,8             ;# list7 = list6:list7 >> 9
+    rlwimi    r22,r21,0,0,8             ;# list6 = list5:list6 >> 9
+    rlwimi    r21,r20,0,0,8             ;# list5 = list4:list5 >> 9
+    rlwimi    r20,r19,0,0,8             ;# list4 = list3:list4 >> 9
+    rlwimi    r19,r18,0,0,8             ;# list3 = list2:list3 >> 9
+    rlwimi    r18,r17,0,0,8             ;# list2 = list1:list2 >> 9
+    rlwimi    r17,r16,0,0,8             ;# list1 = list0:list1 >> 9
+    rlwimi    r16,r13,23,0,8            ;# list0 = newbit:list0 >> 9
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 10
+    rotlwi    r25,r25,10                ;# rotate comp1
+    rotlwi    r26,r26,10                ;# rotate comp2
+    rotlwi    r27,r27,10                ;# rotate comp3
+    rotlwi    r28,r28,10                ;# rotate comp4
+    rotlwi    r29,r29,10                ;# rotate comp5
+    rotlwi    r30,r30,10                ;# rotate comp6
+    rotrwi    r16,r16,10                ;# rotate list0
+    rotrwi    r17,r17,10                ;# rotate list1
+    rotrwi    r18,r18,10                ;# rotate list2
+    rotrwi    r19,r19,10                ;# rotate list3
+    rotrwi    r20,r20,10                ;# rotate list4
+    rotrwi    r21,r21,10                ;# rotate list5
+    rotrwi    r22,r22,10                ;# rotate list6
+    rotrwi    r23,r23,10                ;# rotate list7
+    rlwimi    r24,r25,0,22,31           ;# comp0 = comp0:comp1 << 10
+    rlwimi    r25,r26,0,22,31           ;# comp1 = comp1:comp2 << 10
+    rlwimi    r26,r27,0,22,31           ;# comp2 = comp2:comp3 << 10
+    rlwimi    r27,r28,0,22,31           ;# comp3 = comp3:comp4 << 10
+    rlwimi    r28,r29,0,22,31           ;# comp4 = comp4:comp5 << 10
+    rlwimi    r29,r30,0,22,31           ;# comp5 = comp5:comp6 << 10
+    rlwimi    r30,r31,10,22,31          ;# comp6 = comp6:comp7 << 10
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,9             ;# list7 = list6:list7 >> 10
+    rlwimi    r22,r21,0,0,9             ;# list6 = list5:list6 >> 10
+    rlwimi    r21,r20,0,0,9             ;# list5 = list4:list5 >> 10
+    rlwimi    r20,r19,0,0,9             ;# list4 = list3:list4 >> 10
+    rlwimi    r19,r18,0,0,9             ;# list3 = list2:list3 >> 10
+    rlwimi    r18,r17,0,0,9             ;# list2 = list1:list2 >> 10
+    rlwimi    r17,r16,0,0,9             ;# list1 = list0:list1 >> 10
+    rlwimi    r16,r13,22,0,9            ;# list0 = newbit:list0 >> 10
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 11
+    rotlwi    r25,r25,11                ;# rotate comp1
+    rotlwi    r26,r26,11                ;# rotate comp2
+    rotlwi    r27,r27,11                ;# rotate comp3
+    rotlwi    r28,r28,11                ;# rotate comp4
+    rotlwi    r29,r29,11                ;# rotate comp5
+    rotlwi    r30,r30,11                ;# rotate comp6
+    rotrwi    r16,r16,11                ;# rotate list0
+    rotrwi    r17,r17,11                ;# rotate list1
+    rotrwi    r18,r18,11                ;# rotate list2
+    rotrwi    r19,r19,11                ;# rotate list3
+    rotrwi    r20,r20,11                ;# rotate list4
+    rotrwi    r21,r21,11                ;# rotate list5
+    rotrwi    r22,r22,11                ;# rotate list6
+    rotrwi    r23,r23,11                ;# rotate list7
+    rlwimi    r24,r25,0,21,31           ;# comp0 = comp0:comp1 << 11
+    rlwimi    r25,r26,0,21,31           ;# comp1 = comp1:comp2 << 11
+    rlwimi    r26,r27,0,21,31           ;# comp2 = comp2:comp3 << 11
+    rlwimi    r27,r28,0,21,31           ;# comp3 = comp3:comp4 << 11
+    rlwimi    r28,r29,0,21,31           ;# comp4 = comp4:comp5 << 11
+    rlwimi    r29,r30,0,21,31           ;# comp5 = comp5:comp6 << 11
+    rlwimi    r30,r31,11,21,31          ;# comp6 = comp6:comp7 << 11
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,10            ;# list7 = list6:list7 >> 11
+    rlwimi    r22,r21,0,0,10            ;# list6 = list5:list6 >> 11
+    rlwimi    r21,r20,0,0,10            ;# list5 = list4:list5 >> 11
+    rlwimi    r20,r19,0,0,10            ;# list4 = list3:list4 >> 11
+    rlwimi    r19,r18,0,0,10            ;# list3 = list2:list3 >> 11
+    rlwimi    r18,r17,0,0,10            ;# list2 = list1:list2 >> 11
+    rlwimi    r17,r16,0,0,10            ;# list1 = list0:list1 >> 11
+    rlwimi    r16,r13,21,0,10           ;# list0 = newbit:list0 >> 11
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 12
+    rotlwi    r25,r25,12                ;# rotate comp1
+    rotlwi    r26,r26,12                ;# rotate comp2
+    rotlwi    r27,r27,12                ;# rotate comp3
+    rotlwi    r28,r28,12                ;# rotate comp4
+    rotlwi    r29,r29,12                ;# rotate comp5
+    rotlwi    r30,r30,12                ;# rotate comp6
+    rotrwi    r16,r16,12                ;# rotate list0
+    rotrwi    r17,r17,12                ;# rotate list1
+    rotrwi    r18,r18,12                ;# rotate list2
+    rotrwi    r19,r19,12                ;# rotate list3
+    rotrwi    r20,r20,12                ;# rotate list4
+    rotrwi    r21,r21,12                ;# rotate list5
+    rotrwi    r22,r22,12                ;# rotate list6
+    rotrwi    r23,r23,12                ;# rotate list7
+    rlwimi    r24,r25,0,20,31           ;# comp0 = comp0:comp1 << 12
+    rlwimi    r25,r26,0,20,31           ;# comp1 = comp1:comp2 << 12
+    rlwimi    r26,r27,0,20,31           ;# comp2 = comp2:comp3 << 12
+    rlwimi    r27,r28,0,20,31           ;# comp3 = comp3:comp4 << 12
+    rlwimi    r28,r29,0,20,31           ;# comp4 = comp4:comp5 << 12
+    rlwimi    r29,r30,0,20,31           ;# comp5 = comp5:comp6 << 12
+    rlwimi    r30,r31,12,20,31          ;# comp6 = comp6:comp7 << 12
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,11            ;# list7 = list6:list7 >> 12
+    rlwimi    r22,r21,0,0,11            ;# list6 = list5:list6 >> 12
+    rlwimi    r21,r20,0,0,11            ;# list5 = list4:list5 >> 12
+    rlwimi    r20,r19,0,0,11            ;# list4 = list3:list4 >> 12
+    rlwimi    r19,r18,0,0,11            ;# list3 = list2:list3 >> 12
+    rlwimi    r18,r17,0,0,11            ;# list2 = list1:list2 >> 12
+    rlwimi    r17,r16,0,0,11            ;# list1 = list0:list1 >> 12
+    rlwimi    r16,r13,20,0,11           ;# list0 = newbit:list0 >> 12
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 13
+    rotlwi    r25,r25,13                ;# rotate comp1
+    rotlwi    r26,r26,13                ;# rotate comp2
+    rotlwi    r27,r27,13                ;# rotate comp3
+    rotlwi    r28,r28,13                ;# rotate comp4
+    rotlwi    r29,r29,13                ;# rotate comp5
+    rotlwi    r30,r30,13                ;# rotate comp6
+    rotrwi    r16,r16,13                ;# rotate list0
+    rotrwi    r17,r17,13                ;# rotate list1
+    rotrwi    r18,r18,13                ;# rotate list2
+    rotrwi    r19,r19,13                ;# rotate list3
+    rotrwi    r20,r20,13                ;# rotate list4
+    rotrwi    r21,r21,13                ;# rotate list5
+    rotrwi    r22,r22,13                ;# rotate list6
+    rotrwi    r23,r23,13                ;# rotate list7
+    rlwimi    r24,r25,0,19,31           ;# comp0 = comp0:comp1 << 13
+    rlwimi    r25,r26,0,19,31           ;# comp1 = comp1:comp2 << 13
+    rlwimi    r26,r27,0,19,31           ;# comp2 = comp2:comp3 << 13
+    rlwimi    r27,r28,0,19,31           ;# comp3 = comp3:comp4 << 13
+    rlwimi    r28,r29,0,19,31           ;# comp4 = comp4:comp5 << 13
+    rlwimi    r29,r30,0,19,31           ;# comp5 = comp5:comp6 << 13
+    rlwimi    r30,r31,13,19,31          ;# comp6 = comp6:comp7 << 13
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,12            ;# list7 = list6:list7 >> 13
+    rlwimi    r22,r21,0,0,12            ;# list6 = list5:list6 >> 13
+    rlwimi    r21,r20,0,0,12            ;# list5 = list4:list5 >> 13
+    rlwimi    r20,r19,0,0,12            ;# list4 = list3:list4 >> 13
+    rlwimi    r19,r18,0,0,12            ;# list3 = list2:list3 >> 13
+    rlwimi    r18,r17,0,0,12            ;# list2 = list1:list2 >> 13
+    rlwimi    r17,r16,0,0,12            ;# list1 = list0:list1 >> 13
+    rlwimi    r16,r13,19,0,12           ;# list0 = newbit:list0 >> 13
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 14
+    rotlwi    r25,r25,14                ;# rotate comp1
+    rotlwi    r26,r26,14                ;# rotate comp2
+    rotlwi    r27,r27,14                ;# rotate comp3
+    rotlwi    r28,r28,14                ;# rotate comp4
+    rotlwi    r29,r29,14                ;# rotate comp5
+    rotlwi    r30,r30,14                ;# rotate comp6
+    rotrwi    r16,r16,14                ;# rotate list0
+    rotrwi    r17,r17,14                ;# rotate list1
+    rotrwi    r18,r18,14                ;# rotate list2
+    rotrwi    r19,r19,14                ;# rotate list3
+    rotrwi    r20,r20,14                ;# rotate list4
+    rotrwi    r21,r21,14                ;# rotate list5
+    rotrwi    r22,r22,14                ;# rotate list6
+    rotrwi    r23,r23,14                ;# rotate list7
+    rlwimi    r24,r25,0,18,31           ;# comp0 = comp0:comp1 << 14
+    rlwimi    r25,r26,0,18,31           ;# comp1 = comp1:comp2 << 14
+    rlwimi    r26,r27,0,18,31           ;# comp2 = comp2:comp3 << 14
+    rlwimi    r27,r28,0,18,31           ;# comp3 = comp3:comp4 << 14
+    rlwimi    r28,r29,0,18,31           ;# comp4 = comp4:comp5 << 14
+    rlwimi    r29,r30,0,18,31           ;# comp5 = comp5:comp6 << 14
+    rlwimi    r30,r31,14,18,31          ;# comp6 = comp6:comp7 << 14
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,13            ;# list7 = list6:list7 >> 14
+    rlwimi    r22,r21,0,0,13            ;# list6 = list5:list6 >> 14
+    rlwimi    r21,r20,0,0,13            ;# list5 = list4:list5 >> 14
+    rlwimi    r20,r19,0,0,13            ;# list4 = list3:list4 >> 14
+    rlwimi    r19,r18,0,0,13            ;# list3 = list2:list3 >> 14
+    rlwimi    r18,r17,0,0,13            ;# list2 = list1:list2 >> 14
+    rlwimi    r17,r16,0,0,13            ;# list1 = list0:list1 >> 14
+    rlwimi    r16,r13,18,0,13           ;# list0 = newbit:list0 >> 14
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 15
+    rotlwi    r25,r25,15                ;# rotate comp1
+    rotlwi    r26,r26,15                ;# rotate comp2
+    rotlwi    r27,r27,15                ;# rotate comp3
+    rotlwi    r28,r28,15                ;# rotate comp4
+    rotlwi    r29,r29,15                ;# rotate comp5
+    rotlwi    r30,r30,15                ;# rotate comp6
+    rotrwi    r16,r16,15                ;# rotate list0
+    rotrwi    r17,r17,15                ;# rotate list1
+    rotrwi    r18,r18,15                ;# rotate list2
+    rotrwi    r19,r19,15                ;# rotate list3
+    rotrwi    r20,r20,15                ;# rotate list4
+    rotrwi    r21,r21,15                ;# rotate list5
+    rotrwi    r22,r22,15                ;# rotate list6
+    rotrwi    r23,r23,15                ;# rotate list7
+    rlwimi    r24,r25,0,17,31           ;# comp0 = comp0:comp1 << 15
+    rlwimi    r25,r26,0,17,31           ;# comp1 = comp1:comp2 << 15
+    rlwimi    r26,r27,0,17,31           ;# comp2 = comp2:comp3 << 15
+    rlwimi    r27,r28,0,17,31           ;# comp3 = comp3:comp4 << 15
+    rlwimi    r28,r29,0,17,31           ;# comp4 = comp4:comp5 << 15
+    rlwimi    r29,r30,0,17,31           ;# comp5 = comp5:comp6 << 15
+    rlwimi    r30,r31,15,17,31          ;# comp6 = comp6:comp7 << 15
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,14            ;# list7 = list6:list7 >> 15
+    rlwimi    r22,r21,0,0,14            ;# list6 = list5:list6 >> 15
+    rlwimi    r21,r20,0,0,14            ;# list5 = list4:list5 >> 15
+    rlwimi    r20,r19,0,0,14            ;# list4 = list3:list4 >> 15
+    rlwimi    r19,r18,0,0,14            ;# list3 = list2:list3 >> 15
+    rlwimi    r18,r17,0,0,14            ;# list2 = list1:list2 >> 15
+    rlwimi    r17,r16,0,0,14            ;# list1 = list0:list1 >> 15
+    rlwimi    r16,r13,17,0,14           ;# list0 = newbit:list0 >> 15
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 16
+    rotlwi    r25,r25,16                ;# rotate comp1
+    rotlwi    r26,r26,16                ;# rotate comp2
+    rotlwi    r27,r27,16                ;# rotate comp3
+    rotlwi    r28,r28,16                ;# rotate comp4
+    rotlwi    r29,r29,16                ;# rotate comp5
+    rotlwi    r30,r30,16                ;# rotate comp6
+    rotrwi    r16,r16,16                ;# rotate list0
+    rotrwi    r17,r17,16                ;# rotate list1
+    rotrwi    r18,r18,16                ;# rotate list2
+    rotrwi    r19,r19,16                ;# rotate list3
+    rotrwi    r20,r20,16                ;# rotate list4
+    rotrwi    r21,r21,16                ;# rotate list5
+    rotrwi    r22,r22,16                ;# rotate list6
+    rotrwi    r23,r23,16                ;# rotate list7
+    rlwimi    r24,r25,0,16,31           ;# comp0 = comp0:comp1 << 16
+    rlwimi    r25,r26,0,16,31           ;# comp1 = comp1:comp2 << 16
+    rlwimi    r26,r27,0,16,31           ;# comp2 = comp2:comp3 << 16
+    rlwimi    r27,r28,0,16,31           ;# comp3 = comp3:comp4 << 16
+    rlwimi    r28,r29,0,16,31           ;# comp4 = comp4:comp5 << 16
+    rlwimi    r29,r30,0,16,31           ;# comp5 = comp5:comp6 << 16
+    rlwimi    r30,r31,16,16,31          ;# comp6 = comp6:comp7 << 16
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,15            ;# list7 = list6:list7 >> 16
+    rlwimi    r22,r21,0,0,15            ;# list6 = list5:list6 >> 16
+    rlwimi    r21,r20,0,0,15            ;# list5 = list4:list5 >> 16
+    rlwimi    r20,r19,0,0,15            ;# list4 = list3:list4 >> 16
+    rlwimi    r19,r18,0,0,15            ;# list3 = list2:list3 >> 16
+    rlwimi    r18,r17,0,0,15            ;# list2 = list1:list2 >> 16
+    rlwimi    r17,r16,0,0,15            ;# list1 = list0:list1 >> 16
+    rlwimi    r16,r13,16,0,15           ;# list0 = newbit:list0 >> 16
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 17
+    rotlwi    r25,r25,17                ;# rotate comp1
+    rotlwi    r26,r26,17                ;# rotate comp2
+    rotlwi    r27,r27,17                ;# rotate comp3
+    rotlwi    r28,r28,17                ;# rotate comp4
+    rotlwi    r29,r29,17                ;# rotate comp5
+    rotlwi    r30,r30,17                ;# rotate comp6
+    rotrwi    r16,r16,17                ;# rotate list0
+    rotrwi    r17,r17,17                ;# rotate list1
+    rotrwi    r18,r18,17                ;# rotate list2
+    rotrwi    r19,r19,17                ;# rotate list3
+    rotrwi    r20,r20,17                ;# rotate list4
+    rotrwi    r21,r21,17                ;# rotate list5
+    rotrwi    r22,r22,17                ;# rotate list6
+    rotrwi    r23,r23,17                ;# rotate list7
+    rlwimi    r24,r25,0,15,31           ;# comp0 = comp0:comp1 << 17
+    rlwimi    r25,r26,0,15,31           ;# comp1 = comp1:comp2 << 17
+    rlwimi    r26,r27,0,15,31           ;# comp2 = comp2:comp3 << 17
+    rlwimi    r27,r28,0,15,31           ;# comp3 = comp3:comp4 << 17
+    rlwimi    r28,r29,0,15,31           ;# comp4 = comp4:comp5 << 17
+    rlwimi    r29,r30,0,15,31           ;# comp5 = comp5:comp6 << 17
+    rlwimi    r30,r31,17,15,31          ;# comp6 = comp6:comp7 << 17
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,16            ;# list7 = list6:list7 >> 17
+    rlwimi    r22,r21,0,0,16            ;# list6 = list5:list6 >> 17
+    rlwimi    r21,r20,0,0,16            ;# list5 = list4:list5 >> 17
+    rlwimi    r20,r19,0,0,16            ;# list4 = list3:list4 >> 17
+    rlwimi    r19,r18,0,0,16            ;# list3 = list2:list3 >> 17
+    rlwimi    r18,r17,0,0,16            ;# list2 = list1:list2 >> 17
+    rlwimi    r17,r16,0,0,16            ;# list1 = list0:list1 >> 17
+    rlwimi    r16,r13,15,0,16           ;# list0 = newbit:list0 >> 17
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 18
+    rotlwi    r25,r25,18                ;# rotate comp1
+    rotlwi    r26,r26,18                ;# rotate comp2
+    rotlwi    r27,r27,18                ;# rotate comp3
+    rotlwi    r28,r28,18                ;# rotate comp4
+    rotlwi    r29,r29,18                ;# rotate comp5
+    rotlwi    r30,r30,18                ;# rotate comp6
+    rotrwi    r16,r16,18                ;# rotate list0
+    rotrwi    r17,r17,18                ;# rotate list1
+    rotrwi    r18,r18,18                ;# rotate list2
+    rotrwi    r19,r19,18                ;# rotate list3
+    rotrwi    r20,r20,18                ;# rotate list4
+    rotrwi    r21,r21,18                ;# rotate list5
+    rotrwi    r22,r22,18                ;# rotate list6
+    rotrwi    r23,r23,18                ;# rotate list7
+    rlwimi    r24,r25,0,14,31           ;# comp0 = comp0:comp1 << 18
+    rlwimi    r25,r26,0,14,31           ;# comp1 = comp1:comp2 << 18
+    rlwimi    r26,r27,0,14,31           ;# comp2 = comp2:comp3 << 18
+    rlwimi    r27,r28,0,14,31           ;# comp3 = comp3:comp4 << 18
+    rlwimi    r28,r29,0,14,31           ;# comp4 = comp4:comp5 << 18
+    rlwimi    r29,r30,0,14,31           ;# comp5 = comp5:comp6 << 18
+    rlwimi    r30,r31,18,14,31          ;# comp6 = comp6:comp7 << 18
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,17            ;# list7 = list6:list7 >> 18
+    rlwimi    r22,r21,0,0,17            ;# list6 = list5:list6 >> 18
+    rlwimi    r21,r20,0,0,17            ;# list5 = list4:list5 >> 18
+    rlwimi    r20,r19,0,0,17            ;# list4 = list3:list4 >> 18
+    rlwimi    r19,r18,0,0,17            ;# list3 = list2:list3 >> 18
+    rlwimi    r18,r17,0,0,17            ;# list2 = list1:list2 >> 18
+    rlwimi    r17,r16,0,0,17            ;# list1 = list0:list1 >> 18
+    rlwimi    r16,r13,14,0,17           ;# list0 = newbit:list0 >> 18
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 19
+    rotlwi    r25,r25,19                ;# rotate comp1
+    rotlwi    r26,r26,19                ;# rotate comp2
+    rotlwi    r27,r27,19                ;# rotate comp3
+    rotlwi    r28,r28,19                ;# rotate comp4
+    rotlwi    r29,r29,19                ;# rotate comp5
+    rotlwi    r30,r30,19                ;# rotate comp6
+    rotrwi    r16,r16,19                ;# rotate list0
+    rotrwi    r17,r17,19                ;# rotate list1
+    rotrwi    r18,r18,19                ;# rotate list2
+    rotrwi    r19,r19,19                ;# rotate list3
+    rotrwi    r20,r20,19                ;# rotate list4
+    rotrwi    r21,r21,19                ;# rotate list5
+    rotrwi    r22,r22,19                ;# rotate list6
+    rotrwi    r23,r23,19                ;# rotate list7
+    rlwimi    r24,r25,0,13,31           ;# comp0 = comp0:comp1 << 19
+    rlwimi    r25,r26,0,13,31           ;# comp1 = comp1:comp2 << 19
+    rlwimi    r26,r27,0,13,31           ;# comp2 = comp2:comp3 << 19
+    rlwimi    r27,r28,0,13,31           ;# comp3 = comp3:comp4 << 19
+    rlwimi    r28,r29,0,13,31           ;# comp4 = comp4:comp5 << 19
+    rlwimi    r29,r30,0,13,31           ;# comp5 = comp5:comp6 << 19
+    rlwimi    r30,r31,19,13,31          ;# comp6 = comp6:comp7 << 19
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,18            ;# list7 = list6:list7 >> 19
+    rlwimi    r22,r21,0,0,18            ;# list6 = list5:list6 >> 19
+    rlwimi    r21,r20,0,0,18            ;# list5 = list4:list5 >> 19
+    rlwimi    r20,r19,0,0,18            ;# list4 = list3:list4 >> 19
+    rlwimi    r19,r18,0,0,18            ;# list3 = list2:list3 >> 19
+    rlwimi    r18,r17,0,0,18            ;# list2 = list1:list2 >> 19
+    rlwimi    r17,r16,0,0,18            ;# list1 = list0:list1 >> 19
+    rlwimi    r16,r13,13,0,18           ;# list0 = newbit:list0 >> 19
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 20
+    rotlwi    r25,r25,20                ;# rotate comp1
+    rotlwi    r26,r26,20                ;# rotate comp2
+    rotlwi    r27,r27,20                ;# rotate comp3
+    rotlwi    r28,r28,20                ;# rotate comp4
+    rotlwi    r29,r29,20                ;# rotate comp5
+    rotlwi    r30,r30,20                ;# rotate comp6
+    rotrwi    r16,r16,20                ;# rotate list0
+    rotrwi    r17,r17,20                ;# rotate list1
+    rotrwi    r18,r18,20                ;# rotate list2
+    rotrwi    r19,r19,20                ;# rotate list3
+    rotrwi    r20,r20,20                ;# rotate list4
+    rotrwi    r21,r21,20                ;# rotate list5
+    rotrwi    r22,r22,20                ;# rotate list6
+    rotrwi    r23,r23,20                ;# rotate list7
+    rlwimi    r24,r25,0,12,31           ;# comp0 = comp0:comp1 << 20
+    rlwimi    r25,r26,0,12,31           ;# comp1 = comp1:comp2 << 20
+    rlwimi    r26,r27,0,12,31           ;# comp2 = comp2:comp3 << 20
+    rlwimi    r27,r28,0,12,31           ;# comp3 = comp3:comp4 << 20
+    rlwimi    r28,r29,0,12,31           ;# comp4 = comp4:comp5 << 20
+    rlwimi    r29,r30,0,12,31           ;# comp5 = comp5:comp6 << 20
+    rlwimi    r30,r31,20,12,31          ;# comp6 = comp6:comp7 << 20
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,19            ;# list7 = list6:list7 >> 20
+    rlwimi    r22,r21,0,0,19            ;# list6 = list5:list6 >> 20
+    rlwimi    r21,r20,0,0,19            ;# list5 = list4:list5 >> 20
+    rlwimi    r20,r19,0,0,19            ;# list4 = list3:list4 >> 20
+    rlwimi    r19,r18,0,0,19            ;# list3 = list2:list3 >> 20
+    rlwimi    r18,r17,0,0,19            ;# list2 = list1:list2 >> 20
+    rlwimi    r17,r16,0,0,19            ;# list1 = list0:list1 >> 20
+    rlwimi    r16,r13,12,0,19           ;# list0 = newbit:list0 >> 20
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 21
+    rotlwi    r25,r25,21                ;# rotate comp1
+    rotlwi    r26,r26,21                ;# rotate comp2
+    rotlwi    r27,r27,21                ;# rotate comp3
+    rotlwi    r28,r28,21                ;# rotate comp4
+    rotlwi    r29,r29,21                ;# rotate comp5
+    rotlwi    r30,r30,21                ;# rotate comp6
+    rotrwi    r16,r16,21                ;# rotate list0
+    rotrwi    r17,r17,21                ;# rotate list1
+    rotrwi    r18,r18,21                ;# rotate list2
+    rotrwi    r19,r19,21                ;# rotate list3
+    rotrwi    r20,r20,21                ;# rotate list4
+    rotrwi    r21,r21,21                ;# rotate list5
+    rotrwi    r22,r22,21                ;# rotate list6
+    rotrwi    r23,r23,21                ;# rotate list7
+    rlwimi    r24,r25,0,11,31           ;# comp0 = comp0:comp1 << 21
+    rlwimi    r25,r26,0,11,31           ;# comp1 = comp1:comp2 << 21
+    rlwimi    r26,r27,0,11,31           ;# comp2 = comp2:comp3 << 21
+    rlwimi    r27,r28,0,11,31           ;# comp3 = comp3:comp4 << 21
+    rlwimi    r28,r29,0,11,31           ;# comp4 = comp4:comp5 << 21
+    rlwimi    r29,r30,0,11,31           ;# comp5 = comp5:comp6 << 21
+    rlwimi    r30,r31,21,11,31          ;# comp6 = comp6:comp7 << 21
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,20            ;# list7 = list6:list7 >> 21
+    rlwimi    r22,r21,0,0,20            ;# list6 = list5:list6 >> 21
+    rlwimi    r21,r20,0,0,20            ;# list5 = list4:list5 >> 21
+    rlwimi    r20,r19,0,0,20            ;# list4 = list3:list4 >> 21
+    rlwimi    r19,r18,0,0,20            ;# list3 = list2:list3 >> 21
+    rlwimi    r18,r17,0,0,20            ;# list2 = list1:list2 >> 21
+    rlwimi    r17,r16,0,0,20            ;# list1 = list0:list1 >> 21
+    rlwimi    r16,r13,11,0,20           ;# list0 = newbit:list0 >> 21
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 22
+    rotlwi    r25,r25,22                ;# rotate comp1
+    rotlwi    r26,r26,22                ;# rotate comp2
+    rotlwi    r27,r27,22                ;# rotate comp3
+    rotlwi    r28,r28,22                ;# rotate comp4
+    rotlwi    r29,r29,22                ;# rotate comp5
+    rotlwi    r30,r30,22                ;# rotate comp6
+    rotrwi    r16,r16,22                ;# rotate list0
+    rotrwi    r17,r17,22                ;# rotate list1
+    rotrwi    r18,r18,22                ;# rotate list2
+    rotrwi    r19,r19,22                ;# rotate list3
+    rotrwi    r20,r20,22                ;# rotate list4
+    rotrwi    r21,r21,22                ;# rotate list5
+    rotrwi    r22,r22,22                ;# rotate list6
+    rotrwi    r23,r23,22                ;# rotate list7
+    rlwimi    r24,r25,0,10,31           ;# comp0 = comp0:comp1 << 22
+    rlwimi    r25,r26,0,10,31           ;# comp1 = comp1:comp2 << 22
+    rlwimi    r26,r27,0,10,31           ;# comp2 = comp2:comp3 << 22
+    rlwimi    r27,r28,0,10,31           ;# comp3 = comp3:comp4 << 22
+    rlwimi    r28,r29,0,10,31           ;# comp4 = comp4:comp5 << 22
+    rlwimi    r29,r30,0,10,31           ;# comp5 = comp5:comp6 << 22
+    rlwimi    r30,r31,22,10,31          ;# comp6 = comp6:comp7 << 22
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,21            ;# list7 = list6:list7 >> 22
+    rlwimi    r22,r21,0,0,21            ;# list6 = list5:list6 >> 22
+    rlwimi    r21,r20,0,0,21            ;# list5 = list4:list5 >> 22
+    rlwimi    r20,r19,0,0,21            ;# list4 = list3:list4 >> 22
+    rlwimi    r19,r18,0,0,21            ;# list3 = list2:list3 >> 22
+    rlwimi    r18,r17,0,0,21            ;# list2 = list1:list2 >> 22
+    rlwimi    r17,r16,0,0,21            ;# list1 = list0:list1 >> 22
+    rlwimi    r16,r13,10,0,21           ;# list0 = newbit:list0 >> 22
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 23
+    rotlwi    r25,r25,23                ;# rotate comp1
+    rotlwi    r26,r26,23                ;# rotate comp2
+    rotlwi    r27,r27,23                ;# rotate comp3
+    rotlwi    r28,r28,23                ;# rotate comp4
+    rotlwi    r29,r29,23                ;# rotate comp5
+    rotlwi    r30,r30,23                ;# rotate comp6
+    rotrwi    r16,r16,23                ;# rotate list0
+    rotrwi    r17,r17,23                ;# rotate list1
+    rotrwi    r18,r18,23                ;# rotate list2
+    rotrwi    r19,r19,23                ;# rotate list3
+    rotrwi    r20,r20,23                ;# rotate list4
+    rotrwi    r21,r21,23                ;# rotate list5
+    rotrwi    r22,r22,23                ;# rotate list6
+    rotrwi    r23,r23,23                ;# rotate list7
+    rlwimi    r24,r25,0,9,31            ;# comp0 = comp0:comp1 << 23
+    rlwimi    r25,r26,0,9,31            ;# comp1 = comp1:comp2 << 23
+    rlwimi    r26,r27,0,9,31            ;# comp2 = comp2:comp3 << 23
+    rlwimi    r27,r28,0,9,31            ;# comp3 = comp3:comp4 << 23
+    rlwimi    r28,r29,0,9,31            ;# comp4 = comp4:comp5 << 23
+    rlwimi    r29,r30,0,9,31            ;# comp5 = comp5:comp6 << 23
+    rlwimi    r30,r31,23,9,31           ;# comp6 = comp6:comp7 << 23
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,22            ;# list7 = list6:list7 >> 23
+    rlwimi    r22,r21,0,0,22            ;# list6 = list5:list6 >> 23
+    rlwimi    r21,r20,0,0,22            ;# list5 = list4:list5 >> 23
+    rlwimi    r20,r19,0,0,22            ;# list4 = list3:list4 >> 23
+    rlwimi    r19,r18,0,0,22            ;# list3 = list2:list3 >> 23
+    rlwimi    r18,r17,0,0,22            ;# list2 = list1:list2 >> 23
+    rlwimi    r17,r16,0,0,22            ;# list1 = list0:list1 >> 23
+    rlwimi    r16,r13,9,0,22            ;# list0 = newbit:list0 >> 23
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 24
+    rotlwi    r25,r25,24                ;# rotate comp1
+    rotlwi    r26,r26,24                ;# rotate comp2
+    rotlwi    r27,r27,24                ;# rotate comp3
+    rotlwi    r28,r28,24                ;# rotate comp4
+    rotlwi    r29,r29,24                ;# rotate comp5
+    rotlwi    r30,r30,24                ;# rotate comp6
+    rotrwi    r16,r16,24                ;# rotate list0
+    rotrwi    r17,r17,24                ;# rotate list1
+    rotrwi    r18,r18,24                ;# rotate list2
+    rotrwi    r19,r19,24                ;# rotate list3
+    rotrwi    r20,r20,24                ;# rotate list4
+    rotrwi    r21,r21,24                ;# rotate list5
+    rotrwi    r22,r22,24                ;# rotate list6
+    rotrwi    r23,r23,24                ;# rotate list7
+    rlwimi    r24,r25,0,8,31            ;# comp0 = comp0:comp1 << 24
+    rlwimi    r25,r26,0,8,31            ;# comp1 = comp1:comp2 << 24
+    rlwimi    r26,r27,0,8,31            ;# comp2 = comp2:comp3 << 24
+    rlwimi    r27,r28,0,8,31            ;# comp3 = comp3:comp4 << 24
+    rlwimi    r28,r29,0,8,31            ;# comp4 = comp4:comp5 << 24
+    rlwimi    r29,r30,0,8,31            ;# comp5 = comp5:comp6 << 24
+    rlwimi    r30,r31,24,8,31           ;# comp6 = comp6:comp7 << 24
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,23            ;# list7 = list6:list7 >> 24
+    rlwimi    r22,r21,0,0,23            ;# list6 = list5:list6 >> 24
+    rlwimi    r21,r20,0,0,23            ;# list5 = list4:list5 >> 24
+    rlwimi    r20,r19,0,0,23            ;# list4 = list3:list4 >> 24
+    rlwimi    r19,r18,0,0,23            ;# list3 = list2:list3 >> 24
+    rlwimi    r18,r17,0,0,23            ;# list2 = list1:list2 >> 24
+    rlwimi    r17,r16,0,0,23            ;# list1 = list0:list1 >> 24
+    rlwimi    r16,r13,8,0,23            ;# list0 = newbit:list0 >> 24
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 25
+    rotlwi    r25,r25,25                ;# rotate comp1
+    rotlwi    r26,r26,25                ;# rotate comp2
+    rotlwi    r27,r27,25                ;# rotate comp3
+    rotlwi    r28,r28,25                ;# rotate comp4
+    rotlwi    r29,r29,25                ;# rotate comp5
+    rotlwi    r30,r30,25                ;# rotate comp6
+    rotrwi    r16,r16,25                ;# rotate list0
+    rotrwi    r17,r17,25                ;# rotate list1
+    rotrwi    r18,r18,25                ;# rotate list2
+    rotrwi    r19,r19,25                ;# rotate list3
+    rotrwi    r20,r20,25                ;# rotate list4
+    rotrwi    r21,r21,25                ;# rotate list5
+    rotrwi    r22,r22,25                ;# rotate list6
+    rotrwi    r23,r23,25                ;# rotate list7
+    rlwimi    r24,r25,0,7,31            ;# comp0 = comp0:comp1 << 25
+    rlwimi    r25,r26,0,7,31            ;# comp1 = comp1:comp2 << 25
+    rlwimi    r26,r27,0,7,31            ;# comp2 = comp2:comp3 << 25
+    rlwimi    r27,r28,0,7,31            ;# comp3 = comp3:comp4 << 25
+    rlwimi    r28,r29,0,7,31            ;# comp4 = comp4:comp5 << 25
+    rlwimi    r29,r30,0,7,31            ;# comp5 = comp5:comp6 << 25
+    rlwimi    r30,r31,25,7,31           ;# comp6 = comp6:comp7 << 25
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,24            ;# list7 = list6:list7 >> 25
+    rlwimi    r22,r21,0,0,24            ;# list6 = list5:list6 >> 25
+    rlwimi    r21,r20,0,0,24            ;# list5 = list4:list5 >> 25
+    rlwimi    r20,r19,0,0,24            ;# list4 = list3:list4 >> 25
+    rlwimi    r19,r18,0,0,24            ;# list3 = list2:list3 >> 25
+    rlwimi    r18,r17,0,0,24            ;# list2 = list1:list2 >> 25
+    rlwimi    r17,r16,0,0,24            ;# list1 = list0:list1 >> 25
+    rlwimi    r16,r13,7,0,24            ;# list0 = newbit:list0 >> 25
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 26
+    rotlwi    r25,r25,26                ;# rotate comp1
+    rotlwi    r26,r26,26                ;# rotate comp2
+    rotlwi    r27,r27,26                ;# rotate comp3
+    rotlwi    r28,r28,26                ;# rotate comp4
+    rotlwi    r29,r29,26                ;# rotate comp5
+    rotlwi    r30,r30,26                ;# rotate comp6
+    rotrwi    r16,r16,26                ;# rotate list0
+    rotrwi    r17,r17,26                ;# rotate list1
+    rotrwi    r18,r18,26                ;# rotate list2
+    rotrwi    r19,r19,26                ;# rotate list3
+    rotrwi    r20,r20,26                ;# rotate list4
+    rotrwi    r21,r21,26                ;# rotate list5
+    rotrwi    r22,r22,26                ;# rotate list6
+    rotrwi    r23,r23,26                ;# rotate list7
+    rlwimi    r24,r25,0,6,31            ;# comp0 = comp0:comp1 << 26
+    rlwimi    r25,r26,0,6,31            ;# comp1 = comp1:comp2 << 26
+    rlwimi    r26,r27,0,6,31            ;# comp2 = comp2:comp3 << 26
+    rlwimi    r27,r28,0,6,31            ;# comp3 = comp3:comp4 << 26
+    rlwimi    r28,r29,0,6,31            ;# comp4 = comp4:comp5 << 26
+    rlwimi    r29,r30,0,6,31            ;# comp5 = comp5:comp6 << 26
+    rlwimi    r30,r31,26,6,31           ;# comp6 = comp6:comp7 << 26
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,25            ;# list7 = list6:list7 >> 26
+    rlwimi    r22,r21,0,0,25            ;# list6 = list5:list6 >> 26
+    rlwimi    r21,r20,0,0,25            ;# list5 = list4:list5 >> 26
+    rlwimi    r20,r19,0,0,25            ;# list4 = list3:list4 >> 26
+    rlwimi    r19,r18,0,0,25            ;# list3 = list2:list3 >> 26
+    rlwimi    r18,r17,0,0,25            ;# list2 = list1:list2 >> 26
+    rlwimi    r17,r16,0,0,25            ;# list1 = list0:list1 >> 26
+    rlwimi    r16,r13,6,0,25            ;# list0 = newbit:list0 >> 26
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 27
+    rotlwi    r25,r25,27                ;# rotate comp1
+    rotlwi    r26,r26,27                ;# rotate comp2
+    rotlwi    r27,r27,27                ;# rotate comp3
+    rotlwi    r28,r28,27                ;# rotate comp4
+    rotlwi    r29,r29,27                ;# rotate comp5
+    rotlwi    r30,r30,27                ;# rotate comp6
+    rotrwi    r16,r16,27                ;# rotate list0
+    rotrwi    r17,r17,27                ;# rotate list1
+    rotrwi    r18,r18,27                ;# rotate list2
+    rotrwi    r19,r19,27                ;# rotate list3
+    rotrwi    r20,r20,27                ;# rotate list4
+    rotrwi    r21,r21,27                ;# rotate list5
+    rotrwi    r22,r22,27                ;# rotate list6
+    rotrwi    r23,r23,27                ;# rotate list7
+    rlwimi    r24,r25,0,5,31            ;# comp0 = comp0:comp1 << 27
+    rlwimi    r25,r26,0,5,31            ;# comp1 = comp1:comp2 << 27
+    rlwimi    r26,r27,0,5,31            ;# comp2 = comp2:comp3 << 27
+    rlwimi    r27,r28,0,5,31            ;# comp3 = comp3:comp4 << 27
+    rlwimi    r28,r29,0,5,31            ;# comp4 = comp4:comp5 << 27
+    rlwimi    r29,r30,0,5,31            ;# comp5 = comp5:comp6 << 27
+    rlwimi    r30,r31,27,5,31           ;# comp6 = comp6:comp7 << 27
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,26            ;# list7 = list6:list7 >> 27
+    rlwimi    r22,r21,0,0,26            ;# list6 = list5:list6 >> 27
+    rlwimi    r21,r20,0,0,26            ;# list5 = list4:list5 >> 27
+    rlwimi    r20,r19,0,0,26            ;# list4 = list3:list4 >> 27
+    rlwimi    r19,r18,0,0,26            ;# list3 = list2:list3 >> 27
+    rlwimi    r18,r17,0,0,26            ;# list2 = list1:list2 >> 27
+    rlwimi    r17,r16,0,0,26            ;# list1 = list0:list1 >> 27
+    rlwimi    r16,r13,5,0,26            ;# list0 = newbit:list0 >> 27
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 28
+    rotlwi    r25,r25,28                ;# rotate comp1
+    rotlwi    r26,r26,28                ;# rotate comp2
+    rotlwi    r27,r27,28                ;# rotate comp3
+    rotlwi    r28,r28,28                ;# rotate comp4
+    rotlwi    r29,r29,28                ;# rotate comp5
+    rotlwi    r30,r30,28                ;# rotate comp6
+    rotrwi    r16,r16,28                ;# rotate list0
+    rotrwi    r17,r17,28                ;# rotate list1
+    rotrwi    r18,r18,28                ;# rotate list2
+    rotrwi    r19,r19,28                ;# rotate list3
+    rotrwi    r20,r20,28                ;# rotate list4
+    rotrwi    r21,r21,28                ;# rotate list5
+    rotrwi    r22,r22,28                ;# rotate list6
+    rotrwi    r23,r23,28                ;# rotate list7
+    rlwimi    r24,r25,0,4,31            ;# comp0 = comp0:comp1 << 28
+    rlwimi    r25,r26,0,4,31            ;# comp1 = comp1:comp2 << 28
+    rlwimi    r26,r27,0,4,31            ;# comp2 = comp2:comp3 << 28
+    rlwimi    r27,r28,0,4,31            ;# comp3 = comp3:comp4 << 28
+    rlwimi    r28,r29,0,4,31            ;# comp4 = comp4:comp5 << 28
+    rlwimi    r29,r30,0,4,31            ;# comp5 = comp5:comp6 << 28
+    rlwimi    r30,r31,28,4,31           ;# comp6 = comp6:comp7 << 28
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,27            ;# list7 = list6:list7 >> 28
+    rlwimi    r22,r21,0,0,27            ;# list6 = list5:list6 >> 28
+    rlwimi    r21,r20,0,0,27            ;# list5 = list4:list5 >> 28
+    rlwimi    r20,r19,0,0,27            ;# list4 = list3:list4 >> 28
+    rlwimi    r19,r18,0,0,27            ;# list3 = list2:list3 >> 28
+    rlwimi    r18,r17,0,0,27            ;# list2 = list1:list2 >> 28
+    rlwimi    r17,r16,0,0,27            ;# list1 = list0:list1 >> 28
+    rlwimi    r16,r13,4,0,27            ;# list0 = newbit:list0 >> 28
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 29
+    rotlwi    r25,r25,29                ;# rotate comp1
+    rotlwi    r26,r26,29                ;# rotate comp2
+    rotlwi    r27,r27,29                ;# rotate comp3
+    rotlwi    r28,r28,29                ;# rotate comp4
+    rotlwi    r29,r29,29                ;# rotate comp5
+    rotlwi    r30,r30,29                ;# rotate comp6
+    rotrwi    r16,r16,29                ;# rotate list0
+    rotrwi    r17,r17,29                ;# rotate list1
+    rotrwi    r18,r18,29                ;# rotate list2
+    rotrwi    r19,r19,29                ;# rotate list3
+    rotrwi    r20,r20,29                ;# rotate list4
+    rotrwi    r21,r21,29                ;# rotate list5
+    rotrwi    r22,r22,29                ;# rotate list6
+    rotrwi    r23,r23,29                ;# rotate list7
+    rlwimi    r24,r25,0,3,31            ;# comp0 = comp0:comp1 << 29
+    rlwimi    r25,r26,0,3,31            ;# comp1 = comp1:comp2 << 29
+    rlwimi    r26,r27,0,3,31            ;# comp2 = comp2:comp3 << 29
+    rlwimi    r27,r28,0,3,31            ;# comp3 = comp3:comp4 << 29
+    rlwimi    r28,r29,0,3,31            ;# comp4 = comp4:comp5 << 29
+    rlwimi    r29,r30,0,3,31            ;# comp5 = comp5:comp6 << 29
+    rlwimi    r30,r31,29,3,31           ;# comp6 = comp6:comp7 << 29
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,28            ;# list7 = list6:list7 >> 29
+    rlwimi    r22,r21,0,0,28            ;# list6 = list5:list6 >> 29
+    rlwimi    r21,r20,0,0,28            ;# list5 = list4:list5 >> 29
+    rlwimi    r20,r19,0,0,28            ;# list4 = list3:list4 >> 29
+    rlwimi    r19,r18,0,0,28            ;# list3 = list2:list3 >> 29
+    rlwimi    r18,r17,0,0,28            ;# list2 = list1:list2 >> 29
+    rlwimi    r17,r16,0,0,28            ;# list1 = list0:list1 >> 29
+    rlwimi    r16,r13,3,0,28            ;# list0 = newbit:list0 >> 29
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 30
+    rotlwi    r25,r25,30                ;# rotate comp1
+    rotlwi    r26,r26,30                ;# rotate comp2
+    rotlwi    r27,r27,30                ;# rotate comp3
+    rotlwi    r28,r28,30                ;# rotate comp4
+    rotlwi    r29,r29,30                ;# rotate comp5
+    rotlwi    r30,r30,30                ;# rotate comp6
+    rotrwi    r16,r16,30                ;# rotate list0
+    rotrwi    r17,r17,30                ;# rotate list1
+    rotrwi    r18,r18,30                ;# rotate list2
+    rotrwi    r19,r19,30                ;# rotate list3
+    rotrwi    r20,r20,30                ;# rotate list4
+    rotrwi    r21,r21,30                ;# rotate list5
+    rotrwi    r22,r22,30                ;# rotate list6
+    rotrwi    r23,r23,30                ;# rotate list7
+    rlwimi    r24,r25,0,2,31            ;# comp0 = comp0:comp1 << 30
+    rlwimi    r25,r26,0,2,31            ;# comp1 = comp1:comp2 << 30
+    rlwimi    r26,r27,0,2,31            ;# comp2 = comp2:comp3 << 30
+    rlwimi    r27,r28,0,2,31            ;# comp3 = comp3:comp4 << 30
+    rlwimi    r28,r29,0,2,31            ;# comp4 = comp4:comp5 << 30
+    rlwimi    r29,r30,0,2,31            ;# comp5 = comp5:comp6 << 30
+    rlwimi    r30,r31,30,2,31           ;# comp6 = comp6:comp7 << 30
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,29            ;# list7 = list6:list7 >> 30
+    rlwimi    r22,r21,0,0,29            ;# list6 = list5:list6 >> 30
+    rlwimi    r21,r20,0,0,29            ;# list5 = list4:list5 >> 30
+    rlwimi    r20,r19,0,0,29            ;# list4 = list3:list4 >> 30
+    rlwimi    r19,r18,0,0,29            ;# list3 = list2:list3 >> 30
+    rlwimi    r18,r17,0,0,29            ;# list2 = list1:list2 >> 30
+    rlwimi    r17,r16,0,0,29            ;# list1 = list0:list1 >> 30
+    rlwimi    r16,r13,2,0,29            ;# list0 = newbit:list0 >> 30
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 31
+    rotlwi    r25,r25,31                ;# rotate comp1
+    rotlwi    r26,r26,31                ;# rotate comp2
+    rotlwi    r27,r27,31                ;# rotate comp3
+    rotlwi    r28,r28,31                ;# rotate comp4
+    rotlwi    r29,r29,31                ;# rotate comp5
+    rotlwi    r30,r30,31                ;# rotate comp6
+    rotrwi    r16,r16,31                ;# rotate list0
+    rotrwi    r17,r17,31                ;# rotate list1
+    rotrwi    r18,r18,31                ;# rotate list2
+    rotrwi    r19,r19,31                ;# rotate list3
+    rotrwi    r20,r20,31                ;# rotate list4
+    rotrwi    r21,r21,31                ;# rotate list5
+    rotrwi    r22,r22,31                ;# rotate list6
+    rotrwi    r23,r23,31                ;# rotate list7
+    rlwimi    r24,r25,0,1,31            ;# comp0 = comp0:comp1 << 31
+    rlwimi    r25,r26,0,1,31            ;# comp1 = comp1:comp2 << 31
+    rlwimi    r26,r27,0,1,31            ;# comp2 = comp2:comp3 << 31
+    rlwimi    r27,r28,0,1,31            ;# comp3 = comp3:comp4 << 31
+    rlwimi    r28,r29,0,1,31            ;# comp4 = comp4:comp5 << 31
+    rlwimi    r29,r30,0,1,31            ;# comp5 = comp5:comp6 << 31
+    rlwimi    r30,r31,31,1,31           ;# comp6 = comp6:comp7 << 31
+    slw       r31,r31,r14               ;# shift comp7
+    rlwimi    r23,r22,0,0,30            ;# list7 = list6:list7 >> 31
+    rlwimi    r22,r21,0,0,30            ;# list6 = list5:list6 >> 31
+    rlwimi    r21,r20,0,0,30            ;# list5 = list4:list5 >> 31
+    rlwimi    r20,r19,0,0,30            ;# list4 = list3:list4 >> 31
+    rlwimi    r19,r18,0,0,30            ;# list3 = list2:list3 >> 31
+    rlwimi    r18,r17,0,0,30            ;# list2 = list1:list2 >> 31
+    rlwimi    r17,r16,0,0,30            ;# list1 = list0:list1 >> 31
+    rlwimi    r16,r13,1,0,30            ;# list0 = newbit:list0 >> 31
+    beq-      L_exit                    ;# Ruler found
+    b         L_UpdateLevel
+
+    ;# diff == 32
+    mr        r24,r25                   ;# comp0 = comp1
+    mr        r25,r26                   ;# comp1 = comp2
+    mr        r26,r27                   ;# comp2 = comp3
+    mr        r27,r28                   ;# comp3 = comp4
+    mr        r28,r29                   ;# comp4 = comp5
+    mr        r29,r30                   ;# comp5 = comp6
+    mr        r30,r31                   ;# comp6 = comp7
+    not       r0,r24                    ;# ~comp0
+    li        r31,0                     ;# comp7 = 0
+    srwi      r0,r0,1                   ;# (~comp0) >> 1)
+    mr        r23,r22                   ;# list7 = list6
+    mr        r22,r21                   ;# list6 = list5
+    mr        r21,r20                   ;# list5 = list4
+    mr        r20,r19                   ;# list4 = list3
+    mr        r19,r18                   ;# list3 = list2
+    mr        r18,r17                   ;# list2 = list1
+    mr        r17,r16                   ;# list1 = list0
+    mr        r16,r13                   ;# list0 = newbit
+    li        r13,0                     ;# newbit = 0
+    beq+      cr1,L_MainLoop            ;# comp0 == 0xFFFFFFFF
+    beq-      L_exit                    ;# Ruler found
+
+    nop                                 ;# For alignment purpose
+    nop       
+    nop       
+
+L_UpdateLevel:
+    lwz       r14,Levels_dist+16(r3)    ;# load dist4
+    addi      r6,r6,1                   ;# ++Depth
+    lwz       r15,Levels_dist+20(r3)    ;# load dist5
+    cmplw     cr1,r6,r10                ;# Depth <= MidSegB ?
+    lwz       r0,Levels_dist+24(r3)     ;# load dist6
+    cmplw     cr7,r6,r9                 ;# Depth > MidSegA ?
+    lwz       r13,Levels_dist+28(r3)    ;# load dist7
+    subic.    r4,r4,1                   ;# --nodes <= 0 ?
+    stw       r20,Levels_list+16(r3)    ;# store list4
+    or        r14,r14,r20               ;# dist4 |= list4
+    stw       r21,Levels_list+20(r3)    ;# store list5
+    or        r15,r15,r21               ;# dist5 |= list5
+    stw       r22,Levels_list+24(r3)    ;# store list6
+    or        r0,r0,r22                 ;# dist6 |= list6
+    stw       r23,Levels_list+28(r3)    ;# store list7
+    or        r13,r13,r23               ;# dist7 |= list7
+    stw       r28,Levels_comp+16(r3)    ;# store comp4
+    or        r28,r28,r14               ;# comp4 |=dist4
+    stw       r29,Levels_comp+20(r3)    ;# store comp5
+    or        r29,r29,r15               ;# comp5 |=dist5
+    stw       r30,Levels_comp+24(r3)    ;# store comp6
+    or        r30,r30,r0                ;# comp6 |=dist6
+    stw       r31,Levels_comp+28(r3)    ;# store comp7
+    or        r31,r31,r13               ;# comp7 |=dist7
+    ;# That's not fast, but we ran out of registers...
+    stw       r14,NextLev_dist+16(r3)   ;# store dist4
+    stw       r15,NextLev_dist+20(r3)   ;# store dist5
+    stw       r0,NextLev_dist+24(r3)    ;# store dist6
+    stw       r13,NextLev_dist+28(r3)   ;# store dist7
+    lwz       r13,Levels_dist+0(r3)     ;# load dist0
+    lwz       r14,Levels_dist+4(r3)     ;# load dist1
+    lwz       r15,Levels_dist+8(r3)     ;# load dist2
+    lwz       r0,Levels_dist+12(r3)     ;# load dist3
+    stw       r24,Levels_comp+0(r3)     ;# store comp0
+    or        r13,r13,r16               ;# dist0 |= list0
+    stw       r25,Levels_comp+4(r3)     ;# store comp1
+    or        r14,r14,r17               ;# dist1 |= list1
+    stw       r26,Levels_comp+8(r3)     ;# store comp2
+    or        r15,r15,r18               ;# dist2 |= list2
+    stw       r27,Levels_comp+12(r3)    ;# store comp3
+    or        r0,r0,r19                 ;# dist3 |= list3
+    stw       r13,NextLev_dist+0(r3)    ;# store dist0
+    or        r24,r24,r13               ;# comp0 |= dist0
+    stw       r14,NextLev_dist+4(r3)    ;# store dist1
+    or        r25,r25,r14               ;# comp1 |= dist1
+    stw       r15,NextLev_dist+8(r3)    ;# store dist2
+    or        r26,r26,r15               ;# comp2 |= dist2
+    stw       r0,NextLev_dist+12(r3)    ;# store dist3
+    or        r27,r27,r0                ;# comp3 |= dist3
+    stw       r16,Levels_list+0(r3)     ;# store list0
+    addi      r5,r5,2                   ;# ++pChoose
+    stw       r17,Levels_list+4(r3)     ;# store list1
+    rlwinm    r14,r13,SH,MB,ME          ;# 32*2*(dist0 >> CHOOSE_BITS)
+    stw       r18,Levels_list+8(r3)     ;# store list2
+    not       r0,r24                    ;# c0neg = ~comp0
+    stw       r19,Levels_list+12(r3)    ;# store list3
+    srwi      r0,r0,1                   ;# c0neg = (~comp0) >> 1
+    stw       r7,mark(r3)               ;# Store the current mark
+    addi      r3,r3,SIZEOF_LEVEL        ;# ++Levels
+    lhzx      r8,r14,r5                 ;# load the limit
+    bgt+      cr1,L_LoopBack            ;# Depth > MidSegB
+    ble-      cr7,L_LoopBack            ;# Depth <= MidSegA
+
+L_GetLimit:
+    ;# Compute the limit within the middle segment.
+    ;# This part is only executed when depth == half_depth2 or
+    ;# depth == half_depth2-1 (for odd rulers).
+    ;# cr0 := nodes <= 0
+    ;# cr1 := Depth == MidSegB
+    ;# r8  := limit
+    ;# r13 := dist0
+
+    lwz       r14,pLevelA(r1)           ;# &Levels[MidSegA]
+    lwz       r15,maxLenM1(r1)          ;# maxlen - 1
+    lwz       r14,mark(r14)             ;# Levels[MidSegA].mark
+    sub       r14,r15,r14               ;# temp
+    beq       cr1,L_MinFunc             ;# Depth == MidSegB
+
+    ;# Compute middle mark limit (depth < MidSegB)
+    not       r15,r13                   ;# ~dist0
+    cntlzw    r15,r15                   ;# FFZ(dist0)
+    addi      r15,r15,1
+    sub       r14,r14,r15               ;# temp -= FFZ(dist0)
+
+L_MinFunc:
+    subfc     r15,r8,r14
+    subfe     r14,r14,r14
+    and       r15,r15,r14
+    add       r8,r8,r15                 ;# limit = min(temp, limit)
+
+L_LoopBack:
+    ;# cr0 := nodes <= 0
+    li        r13,1                     ;# newbit = 1
+    stw       r8,limit(r3)              ;# store the limit
+    bgt+      L_MainLoop                ;# nodes > 0
+
+L_exit:
+    ;# Save state
+    stw       r16,Levels_list+0(r3)     ;# store list0
+    stw       r24,Levels_comp+0(r3)     ;# store comp0
+    stw       r17,Levels_list+4(r3)     ;# store list1
+    stw       r25,Levels_comp+4(r3)     ;# store comp1
+    stw       r18,Levels_list+8(r3)     ;# store list2
+    stw       r26,Levels_comp+8(r3)     ;# store comp2
+    stw       r19,Levels_list+12(r3)    ;# store list3
+    stw       r27,Levels_comp+12(r3)    ;# store comp3
+    stw       r20,Levels_list+16(r3)    ;# store list4
+    stw       r28,Levels_comp+16(r3)    ;# store comp4
+    stw       r21,Levels_list+20(r3)    ;# store list5
+    stw       r29,Levels_comp+20(r3)    ;# store comp5
+    stw       r22,Levels_list+24(r3)    ;# store list6
+    stw       r30,Levels_comp+24(r3)    ;# store comp6
+    stw       r23,Levels_list+28(r3)    ;# store list7
+    stw       r31,Levels_comp+28(r3)    ;# store comp7
+
+    stw       r7,mark(r3)               ;# Store the current mark
+    lwz       r8,pNodes(r1)             ;# reload pNodes
+    lwz       r14,0(r8)
+    sub       r14,r14,r4                ;# -= nodes
+    stw       r14,0(r8)                 ;# *pNodes
+    lwz       r2,gpr2(r1)               ;# restore GPR2
+    mr        r3, r6                    ;# return actual depth
+
+
+;#============================================================================
+;# Epilog
+
+    ;# Restore non-volatile registers
+    lwz       r5,0(r1)                  ;# Obtains caller's stack pointer
+    lmw       r13,-GPRSaveArea(r5)      ;# Restore GPRs
+    mr        r1,r5
+    blr       
+

--- a/rc5-72/ppc/r72-KKS604e.gas2.s
+++ b/rc5-72/ppc/r72-KKS604e.gas2.s
@@ -1,0 +1,954 @@
+#
+# RC5-72 Dual key core - MPC604e (System V.4 ABI)
+# TAB = 4
+#
+# Written by Didier Levet (kakace@wanadoo.fr)
+# Copyright distributed.net 1997-2008 - All Rights Reserved
+# For use in distributed.net projects only.
+# Any other distribution or use of this source violates copyright.
+#
+# Hacked from Mac OS X assembler format to 'gas' 2.x format
+# by Monroe Williams <monroe@pobox.com>.
+#
+# This implementation is optimized for MPC604e. 
+# The core checks 2 keys per loop using the integer units.
+#
+# Specifications :
+#	MPC604e
+#		- Fetch/dispatch/retire 4 instructions per clock cycle.
+#		- 2 stages LSU, 2 SCIU.
+#
+# Dependencies : 
+#
+#	struct rc5_72UnitWork (ccoreio.h) :
+#		typedef struct {
+#  			struct {u32 hi,lo;} plain;
+#  			struct {u32 hi,lo;} cypher;
+#  			struct {u32 hi,mid,lo;} L0;
+#  			struct {u32 count; u32 hi,mid,lo;} check;
+#		} RC5_72UnitWork;
+#
+#	MINIMUM_ITERATIONS (problem.cpp) :
+#		The number of iterations to perform is always an even multiple of
+#		MINIMUM_ITERATIONS, and the first key to checked is also an even
+#		multiple of this constant.
+#		Therefore, it is assumed that the number of iterations is never
+#		equal to zero (otherwise it would be interpreted as 2^32). 
+#		The current value of 24 also ensure that we can process 1, 2, 4 or
+#		8 keys at once, all keys (within such "block") having the same mid
+#		and lo values).
+#
+# $Id: r72-KKS604e.gas.s,v 1.5 2008/12/30 20:58:45 andreasb Exp $
+#
+# $Log: r72-KKS604e.gas.s,v $
+# Revision 1.5  2008/12/30 20:58:45  andreasb
+# 2008 copyright bump (all files touched this year)
+#
+# Revision 1.4  2008/10/27 19:45:10  oliver
+# Switch ABI to System V.4 (as MacOS uses separate files anyway)
+#
+# Revision 1.3  2007/10/22 16:48:35  jlawson
+# overwrite head with contents of release-2-90xx
+#
+# Revision 1.1.2.3  2007/03/05 03:39:18  mfeiri
+# explicitly truncate key table to 32 bit
+#
+# Revision 1.1.2.2  2003/03/12 20:31:44  oliver
+# Linker errors when compiled with gas 2.11 - fixed
+# Moved executed_key data from .data to .rodata
+#
+# Revision 1.1.2.1  2003/03/12 12:13:15  snake
+# Added optimized gas compliant cores (like those for MacOS X)
+#
+# Revision 1.1.2.1  2003/01/20 00:26:42  mfeiri
+# New core by kakace for 604
+#
+# Revision 1.3  2003/01/12 21:21:41  kakace
+# The core now uses a static expanded key table instead of computing
+# S[] value dynamically. This frees up the integer units (at the expense
+# of extra LSU instructions) but this should be faster since the MPC604e
+# can retire as much as 4 instructions per cycle, thus reducing the
+# probability of completion queue stalls due to the extra LSU instructions.
+#
+# Revision 1.2  2003/01/12 20:53:57  kakace
+# Fixed key.mid incrementation
+#
+# Revision 1.1  2003/01/12 19:44:36  kakace
+# First implementation
+#
+#============================================================================
+ 
+        .text
+		.align	2
+		.globl	rc5_72_unit_func_KKS604e
+
+# Register aliases
+
+.set    r0,0
+.set    r1,1
+.set    r2,2
+.set    r3,3
+.set    r4,4
+.set    r5,5
+.set    r6,6
+.set    r7,7
+.set    r8,8
+.set    r9,9
+.set    r10,10
+.set    r11,11
+.set    r12,12
+.set    r13,13
+.set    r14,14
+.set    r15,15
+.set    r16,16
+.set    r17,17
+.set    r18,18
+.set    r19,19
+.set    r20,20
+.set    r21,21
+.set    r22,22
+.set    r23,23
+.set    r24,24
+.set    r25,25
+.set    r26,26
+.set    r27,27
+.set    r28,28
+.set    r29,29
+.set    r30,30
+.set    r31,31
+
+# Result values (see ccoreio.h)	
+	
+.set 	RESULT_NOTHING	, 1
+.set 	RESULT_FOUND	, 2
+	
+
+# struct rc5_72unitwork
+
+.set 	plain_hi	,	 0
+.set 	plain_lo	,	 4
+.set 	cypher_hi	,	 8
+.set 	cypher_lo	,	12
+.set 	L0_hi		,	16
+.set 	L0_mid		,	20
+.set 	L0_lo		,	24
+.set 	check_count	,	28
+.set 	check_hi	,	32
+.set 	check_mid	,	36
+.set 	check_lo	,	40
+
+
+# RSA constants
+
+.set 	P	, 0xB7E15163
+.set 	Q	, 0x9E3779B9
+
+
+# stack frame (System V.4 ABI)
+# The floating-point register save area and the parameter list
+# area remain empty. Therefore, the stack frame looks like this :
+#	General register save area
+#	Local variable space
+#	Linkage area
+
+.set 	oldLR		,	4			# 4(sp) stores the old LR (caller's frame)
+.set 	numGPRs		,	32-13		# r13 to r31
+
+	# The linkageArea size, as defined by Apple, is equal to 24. Since we
+	# have to align our local variable space to an address that is an
+	# even multiple of 16, we shall add an extra padding. Of course, the
+	# padding area could be used to save some local variables.
+
+.set 	linkageArea	,	8			# Size of the linkageArea.
+
+
+# Local variables area
+# Offsets (from the callee's SP) to the local variable space.
+
+.set 	saveR2	,	linkageArea		# Storage for r2 (defined as volatile under
+								# MacOS X, but usually points to RTOC).
+.set 	Key		,	saveR2 + 4		# key.hi, key.mid, key.lo
+
+.set 	S_00	,	Key + 12
+.set 	S_01	,	S_00 + 8
+.set 	S_02	,	S_01 + 8
+.set 	S_03	,	S_02 + 8
+.set 	S_04	,	S_03 + 8
+.set 	S_05	,	S_04 + 8
+.set 	S_06	,	S_05 + 8
+.set 	S_07	,	S_06 + 8
+.set 	S_08	,	S_07 + 8
+.set 	S_09	,	S_08 + 8
+.set 	S_10	,	S_09 + 8
+.set 	S_11	,	S_10 + 8
+.set 	S_12	,	S_11 + 8
+.set 	S_13	,	S_12 + 8
+.set 	S_14	,	S_13 + 8
+.set 	S_15	,	S_14 + 8
+.set 	S_16	,	S_15 + 8
+.set 	S_17	,	S_16 + 8
+.set 	S_18	,	S_17 + 8
+.set 	S_19	,	S_18 + 8
+.set 	S_20	,	S_19 + 8
+.set 	S_21	,	S_20 + 8
+.set 	S_22	,	S_21 + 8
+.set 	S_23	,	S_22 + 8
+.set 	S_24	,	S_23 + 8
+.set 	S_25	,	S_24 + 8
+	
+.set 	localTOP	,	(S_25 + 15 + 8) & (-16)
+
+# Total frame size (minus the optional alignment padding).
+
+.set 	frameSize	, localTOP + numGPRs * 4
+	
+# Size of the general register save area. This value is used as a
+# (negative) offset from the caller's SP to save all non-volatile GPRs.
+
+.set 	GPRSave	, numGPRs * 4
+	
+	
+#============================================================================
+#
+# s32 rc5_72_unit_func_MPC604e (RC5_72UnitWork *rc5_72unitwork (r3), 
+#  r3						 	u32 *iterations (r4), 
+#							 	void * /*memblk (r5) */)
+
+rc5_72_unit_func_KKS604e:
+
+	# Prolog
+	# Save r2, LR and GPRs to the stack frame.
+	# Although the Apple ABI states that there's a red zone at negative 
+	# offsets from the stack pointer, I don't use this feature to help 
+	# porting the code to other ABI.
+	# Said otherwise, nothing is written at negative offsets from the 
+	# stack pointer. 
+	#
+	# NOTES : 
+	#	- The stack pointer is assumed to be aligned on a 8-byte 
+	#	  boundary.
+		
+		mflr	r0
+		stw		r0,oldLR(r1)		# LR (to caller's stack frame)
+		mr		r6,r1				# Caller's SP
+				
+		rlwinm	r5,r1,0,28,28		# Adjust the frame size (compute the size
+		subfic	r5,r5,-frameSize	# of the optional alignment padding),
+		stwux	r1,r1,r5			# then create the new stack frame.
+
+	# Save all non-volatile registers (r13-r31)
+		
+		stmw	r13,-GPRSave(r6)	# Save r13-r31
+		stw		r2,saveR2(r1)
+		
+
+	#--------------------------------------------------------------------
+	# Cruncher setup
+	# r3 := struct rc5_72UnitWork *rc5_72unitwork
+	# r4 := u32 *iterations
+	#
+	# According to problem.cpp/MINIMUM_ITERATIONS, the number of keys to
+	# check (iterations) is always an even multiple of 24. The cruncher
+	# is usually asked to check thousands of 24-key blocks (no performance
+	# issues involved here).
+	
+
+		# Save the current key, and keep a big-endian
+		# copy of key.mid and key.lo in r7-r8.
+
+		li		r21,L0_mid
+		li		r22,L0_lo
+		lwz		r6,L0_hi(r3)		# key.hi
+		lwbrx	r7,r3,r21			# key.mid (big-endian)
+		lwbrx	r8,r3,r22			# key.lo (big-endian)
+
+		li		r21,Key+4			# key.mid
+		li		r22,Key+8			# key.lo
+		stw		r6,Key(r1)			# save key.hi
+		stwbrx	r7,r1,r21			# save key.mid
+		stwbrx	r8,r1,r22			# save key.lo
+		
+		# Compute the number of inner loop iterations for the 
+		# first pass (assigned to CTR)
+		
+		lwz		r5,0(r4)			# iterations
+		subfic	r24,r6,0x100		# 0x100 - key.hi
+		cmpl	cr0,r5,r24
+		bgt		set_counter
+		
+		mr		r24,r5
+	
+set_counter:
+		subf	r5,r24,r5			# Remaining iterations.
+		srwi	r24,r24,1			# inner loop count
+		mtctr	r24					# = min(iterations, 0x100 - key.hi) / 2
+
+		# Pre-load contest's values
+		
+		lwz		r2,cypher_lo(r3)
+		
+		#lis		r10,(expanded_key)@ha
+		#la		r10,(expanded_key)@l(r10)
+		bl	bl_trick
+.long expanded_key
+bl_trick:
+		mflr	r10
+		lwz	r10,0(r10)
+		
+
+	#---------------------------------------------------------------------
+	# Main loop. Preconditions :
+	# r2  := cypher.lo
+	# r3  := struct rc5_72UnitWork *rc5_72unitwork
+	# r4  := u32 *iterations
+	# r5  := Remaining iterations after the first pass in the inner loop.
+	# r10 := &expanded_key[0] (constant)
+	# CTR := Inner loop count
+	#
+	# NOTES :
+	# - key.mid changes only every 64 loops, and key.lo 
+	#	probably never change. Therefore, the first rounds are
+	#	as follows :
+	#		A = ROTL3(S[0]);
+	#		B = L[0] = ROTL(L[0] + A, A);
+	#		A = ROTL3(S[1] + A + B);
+	#		B = L[1] = ROTL(L[1] + (A + B), (A + B));
+	#		A = ROTL3(S[2] + A + B);
+	#	where everything remains constant until key.mid or
+	#	key.lo change.
+
+inner_loop_lo:
+		# key.lo changed. Compute s[0], l[0] and s[1].
+		# Preconditions :
+		#	r2  := cypher.lo
+		#	r10 := Q
+		#
+		# Results :
+		#	r11 := l0[0]
+		#	r13 := s[0]
+		#	r14 := s[1]
+		
+		lwz		r13,0(r10)			# S[0]	
+		lwz		r11,Key+8(r1)		# key.lo
+		lwz		r14,4(r10)			# S[1]
+
+		add		r11,r11,r13			# key.lo += a
+		rotlw	r11,r11,r13			# b = L[0] = ROTL(...)
+
+		add		r24,r13,r11			# a + b
+		add		r14,r14,r24			# s[1] = S[1] + (a + b)
+		rotlwi	r14,r14,3			# a = s[1] = ROTL3(...)
+		
+
+inner_loop_mid:
+		# key.mid changed, key.lo unchanged. Compute l[1] and s[2]
+		# Preconditions :
+		#	r2  := cypher.lo
+		#	r10 := &expanded_key[0]
+		#	r11 := l0[0] (b)
+		#	r14 := s[1] (a)
+		#	
+		# Results :
+		#	r9  := S[3] (P + 3Q)
+		#	r12 := l0[1]
+		#	r15 := s[2]
+
+		lwz		r12,Key+4(r1)		# key.mid
+		add		r24,r14,r11			# a + b = s[1] + L[0]
+		add		r12,r12,r24			# key.mid += a + b
+		lwz		r15,8(r10)			# S[2]
+		rotlw	r12,r12,r24			# b = L[1] = ROTL(...)
+		
+		add		r24,r12,r14			# a + b
+		add		r15,r15,r24			# s[2] = S[2] + (a + b)
+		lwz		r9,12(r10)			# S[3]
+		rotlwi	r15,r15,3			# a = s[2] = ROTL3(...)
+
+		
+inner_loop_hi:
+		# key.mid and key.lo unchanged. 
+		# Preconditions :
+		#	r2  := cypher.lo
+		#	r9  := S[3]
+		#	r10 := &expanded_key[0]
+		#	r11 := L[0]
+		#	r12 := L[1] (== b)
+		#	r13 := s[0]
+		#	r14 := s[1]
+		#	r15 := s[2] (== a)
+		#
+		# Registers used :
+		#	r16,r17 := l0[0], l1[0]
+		#	r18,r19 := l0[1], l1[1]
+		#	r20,r21 := l0[2], l1[2]
+		#	r22,r23 := s0[x], s1[x]
+		#	r24,r25 := t0, t1
+		#	r26,r27 := A0, A1 (round stage)
+		#	r28,r29 := B0, B1 (round stage)
+		#
+		# The first steps require specific code since l0[0], l1[0],
+		# l0[1] and l1[1] are not initialized yet. This is done
+		# dynamically by using L[0] and L[1] which are constant
+		# values when key.mid and key.lo remain the same.
+
+		# Step 1.2 : Compute l[2]
+
+		add		r24,r15,r12			# a + b = s[2] + L[1]
+		addi	r21,r6,1			# l1[2] = key.hi + 1
+		add		r20,r6,r24			# l0[2] = key.hi + a + b
+		add		r21,r21,r24			# l1[2] += a + b
+		rotlw	r20,r20,r24			# b0 = l0[2] = ROTL(...) 
+		rotlw	r21,r21,r24			# b1 = l1[2] = ROTL(...)
+
+		# Step 1.3 : Compute s[3] and l[0]
+		
+		add		r24,r15,r20			# t0 = a + b0
+		add		r25,r15,r21			# t1 = a + b1
+		add		r22,r9,r24			# s0[3] = S[3] + t0
+		add		r23,r9,r25			# s1[3] = S[3] + t1
+		rotlwi	r22,r22,3			# a0 = s0[3] = ROTL3(...)
+		rotlwi	r23,r23,3			# a1 = s1[3] = ROTL3(...)
+		
+		add		r24,r22,r20			# t0 = a0 + b0
+		add		r25,r23,r21			# t1 = a1 + b1
+		lwz		r9,16(r10)			# S[4]
+		add		r16,r11,r24			# l0[0] = L[0] + t0
+		add		r17,r11,r25			# l1[0] = L[0] + t1
+		stw		r22,S_03(r1)		# save s0[3]
+		rotlw	r16,r16,r24			# b0 = l0[0] = ROTL(...)
+		rotlw	r17,r17,r25			# b1 = l1[0] = ROTL(...)
+		stw		r23,S_03+4(r1)		# save s1[3]
+		
+		# Step 1.4 : Compute s[4] and l[1]
+		
+		add		r24,r22,r16			# t0 = a0 + b0
+		add		r25,r23,r17			# t1 = a1 + b1
+		add		r22,r9,r24			# s0[4] = S[4] + t0
+		add		r23,r9,r25			# s1[4] = S[4] + t1
+		rotlwi	r22,r22,3			# a0 = s0[4] = ROTL3(...)
+		rotlwi	r23,r23,3			# a1 = s1[4] = ROTL3(...)
+		
+		add		r24,r22,r16			# t0 = a0 + b0
+		add		r25,r23,r17			# t1 = a1 + b1
+		lwz		r9,20(r10)			# S[5]
+		add		r18,r12,r24			# l0[1] = L[1] + t0
+		add		r19,r12,r25			# l1[1] = L[1] + t1
+		stw		r22,S_04(r1)		# save s0[4]
+		rotlw	r18,r18,r24			# b0 = l0[1] = ROTL(...)
+		rotlw	r19,r19,r25			# b1 = l1[1] = ROTL(...)
+		stw		r23,S_04+4(r1)		# save s1[4]
+		
+		# Step 1.5 (partial) : Compute s[5].
+		
+		add		r24,r22,r18			# t0 = a0 + b0
+		add		r25,r23,r19			# t1 = a1 + b1
+		add		r22,r9,r24			# s0[5] = S[5] + t0
+		add		r23,r9,r25			# s1[5] = S[5] + t1
+		rotlwi	r22,r22,3			# a0 = s0[5] = ROTL3(...)
+		rotlwi	r23,r23,3			# a1 = s1[5] = ROTL3(...)
+		
+		add		r24,r22,r18			# t0 = a0 + b0
+		add		r25,r23,r19			# t1 = a1 + b1
+		
+		# The next steps (upto 25) can be implemented
+		# using a macro. Note that in order to reduce the
+		# number of arguments, the code compute l[j] and
+		# s[i] and save s[i-1]
+	
+	.macro	mix1 arg0, arg1, arg2, arg3
+									# l0[j], l1[j], S_kk
+		lwz		r9,\arg3*4(r10)		# S[z]
+		add		\arg0,\arg0,r24			# l0[j] += t0
+		add		\arg1,\arg1,r25			# l1[j] += t1
+		stw		r22,\arg2(r1)			# save s0[k]
+		rotlw	\arg0,\arg0,r24			# b0 = l0[j] = ROTL(...)
+		rotlw	\arg1,\arg1,r25			# b1 = l1[j] = ROTL(...)
+		stw		r23,\arg2+4(r1)		# save s1[k]
+		
+		add		r24,r22,\arg0			# t0 = a0 + b0
+		add		r25,r23,\arg1			# t1 = a1 + b1
+		add		r22,r9,r24			# s0[i] = S[i] + t0
+		add		r23,r9,r25			# s1[i] = S[i] + t1
+		rotlwi	r22,r22,3			# a0 = s0[i] = ROTL3(...)
+		rotlwi	r23,r23,3			# a1 = s1[i] = ROTL3(...)
+		
+		add		r24,r22,\arg0			# t0 = a0 + b0
+		add		r25,r23,\arg1			# t1 = a1 + b1
+	.endm
+
+		mix1	r20,r21,S_05,6		# Step  1.6 : l[2] and s[6]
+		mix1	r16,r17,S_06,7		# Step  1.7 : l[0] and s[7]
+		mix1	r18,r19,S_07,8		# Step  1.8 : l[1] and s[8]
+		mix1	r20,r21,S_08,9		# Step  1.9 : l[2] and s[9]
+		mix1	r16,r17,S_09,10		# Step 1.10 : l[0] and s[10]
+		mix1	r18,r19,S_10,11		# Step 1.11 : l[1] and s[11]
+		mix1	r20,r21,S_11,12		# Step 1.12 : l[2] and s[12]
+		mix1	r16,r17,S_12,13		# Step 1.13 : l[0] and s[13]
+		mix1	r18,r19,S_13,14		# Step 1.14 : l[1] and s[14]
+		mix1	r20,r21,S_14,15		# Step 1.15 : l[2] and s[15]
+		mix1	r16,r17,S_15,16		# Step 1.16 : l[0] and s[16]
+		mix1	r18,r19,S_16,17		# Step 1.17 : l[1] and s[17]
+		mix1	r20,r21,S_17,18		# Step 1.18 : l[2] and s[18]
+		mix1	r16,r17,S_18,19		# Step 1.19 : l[0] and s[19]
+		mix1	r18,r19,S_19,20		# Step 1.20 : l[1] and s[20]
+		mix1	r20,r21,S_20,21		# Step 1.21 : l[2] and s[21]
+		mix1	r16,r17,S_21,22		# Step 1.22 : l[0] and s[22]
+		mix1	r18,r19,S_22,23		# Step 1.23 : l[1] and s[23]
+		mix1	r20,r21,S_23,24		# Step 1.24 : l[2] and s[24]
+		mix1	r16,r17,S_24,25		# Step 1.25 : l[0] and s[25]
+				
+		# Complete step 1.25 (compute l[1])
+		
+		add		r18,r18,r24			# l0[1] += a0 + b0
+		add		r19,r19,r25			# l1[1] += a1 + b1
+		stw		r22,S_25(r1)		# save s0[25]
+		rotlw	r18,r18,r24			# b0 = l0[1] = ROTL(...)
+		rotlw	r19,r19,r25			# b1 = l1[1] = ROTL(...)
+		stw		r23,S_25+4(r1)		# save s1[25]
+
+	#== Pass 2 : Update s[0] ... s[25]
+	#	The first steps require specific code to load
+	#	s[0], s[1] and s[2]. The remaining steps can be
+	#	implemented using a macro.
+	
+		# Step 2.0 : Compute s[0] and l[2]
+	
+		add		r24,r22,r18			# t0 = a0 + b0
+		add		r25,r23,r19			# t1 = a1 + b1
+		add		r22,r13,r24			# s0[0] = s[0] + t0
+		add		r23,r13,r25			# s1[0] = s[0] + t1
+		rotlwi	r22,r22,3			# a0 = s0[0] = ROTL3(...)
+		rotlwi	r23,r23,3			# a1 = s1[0] = ROTL3(...)
+		
+		add		r24,r22,r18			# t0 = a0 + b0
+		add		r25,r23,r19			# t1 = a1 + b1
+		add		r20,r20,r24			# l0[2] += t0
+		add		r21,r21,r25			# l1[2] += t1
+		stw		r22,S_00(r1)		# save s0[0]
+		rotlw	r20,r20,r24			# b0 = l0[2] = ROTL(...)
+		rotlw	r21,r21,r25			# b1 = l1[2] = ROTL(...)
+		stw		r23,S_00+4(r1)		# save s1[0]
+		
+		# Step 2.1 : Compute s[1] and l[0]
+		
+		add		r24,r22,r20			# t0 = a0 + b0
+		add		r25,r23,r21			# t1 = a1 + b1
+		add		r22,r14,r24			# s0[1] = s[1] + t0
+		add		r23,r14,r25			# s1[1] = s[1] + t1
+		rotlwi	r22,r22,3			# a0 = s0[1] = ROTL3(...)
+		rotlwi	r23,r23,3			# a1 = s1[1] = ROTL3(...)
+		
+		add		r24,r22,r20			# t0 = a0 + b0
+		add		r25,r23,r21			# t1 = a1 + b1
+		add		r16,r16,r24			# l0[0] += t0
+		add		r17,r17,r25			# l1[0] += t1
+		stw		r22,S_01(r1)		# save s0[1]
+		rotlw	r16,r16,r24			# b0 = l0[0] = ROTL(...)
+		rotlw	r17,r17,r25			# b1 = l1[0] = ROTL(...)
+		stw		r23,S_01+4(r1)		# save s1[1]
+
+		# Step 2.2 : Compute s[2] and l[1]
+		
+		add		r24,r22,r16			# t0 = a0 + b0
+		add		r25,r23,r17			# t1 = a1 + b1
+		add		r22,r15,r24			# s0[2] = s[2] + t0
+		add		r23,r15,r25			# s1[2] = s[2] + t1
+		rotlwi	r22,r22,3			# a0 = s0[2] = ROTL3(...)
+		rotlwi	r23,r23,3			# a1 = s1[2] = ROTL3(...)
+		
+		lwz		r30,S_03(r1)		# pre-load s0[3]
+		add		r24,r22,r16			# t0 = a0 + b0
+		add		r25,r23,r17			# t1 = a1 + b1
+		lwz		r31,S_03+4(r1)		# pre-load s1[3]
+		add		r18,r18,r24			# l0[1] += t0
+		add		r19,r19,r25			# l1[1] += t1
+		stw		r22,S_02(r1)		# save s0[2]
+		rotlw	r18,r18,r24			# b0 = l0[1] = ROTL(...)
+		rotlw	r19,r19,r25			# b1 = l1[1] = ROTL(...)
+		stw		r23,S_02+4(r1)		# save s1[2]
+
+		# Begin step 2.3 : Compute s[3]
+		
+		add		r24,r22,r18			# t0 = a0 + b0
+		add		r25,r23,r19			# t1 = a1 + b1
+		add		r22,r30,r24			# s0[3] += t0
+		add		r23,r31,r25			# s1[3] += t1
+		rotlwi	r22,r22,3			# a0 = s0[3] = ROTL3(...)
+		rotlwi	r23,r23,3			# a1 = s1[3] = ROTL3(...)
+		
+		add		r24,r22,r18			# t0 = a0 + b0
+		add		r25,r23,r19			# t1 = a1 + b1
+
+
+	.macro	mix2 arg0, arg1, arg2
+									# l0[j], l1[j], S_kk[]
+		lwz		r30,\arg2+8(r1)		# pre-load s0[i+1]
+		add		\arg0,\arg0,r24			# l0[j] += t0
+		add		\arg1,\arg1,r25			# l1[j] += t1
+		lwz		r31,\arg2+12(r1)		# pre-load s1[i+1]
+		rotlw	\arg0,\arg0,r24			# b0 = l0[j] = ROTL(...)
+		rotlw	\arg1,\arg1,r25			# b1 = l1[j] = ROTL(...)
+		stw		r22,\arg2(r1)			# save s0[i]
+		add		r24,r22,\arg0			# t0 = a0 + b0
+		add		r25,r23,\arg1			# t1 = a1 + b1
+		stw		r23,\arg2+4(r1)		# save s1[i]
+		add		r22,r30,r24			# s0[i] += t0
+		add		r23,r31,r25			# s1[i] += t1
+		rotlwi	r22,r22,3			# a0 = s0[i] = ROTL3(...)
+		rotlwi	r23,r23,3			# a1 = s1[i] = ROTL3(...)
+		add		r24,r22,\arg0			# t0 = a0 + b0
+		add		r25,r23,\arg1			# t1 = a1 + b1
+	.endm
+
+		mix2	r20,r21,S_03		# Step  2.4 : l[2] and s[4]
+		mix2	r16,r17,S_04		# Step  2.5 : l[0] and s[5]
+		mix2	r18,r19,S_05		# Step  2.6 : l[1] and s[6]
+		mix2	r20,r21,S_06		# Step  2.7 : l[2] and s[7]
+		mix2	r16,r17,S_07		# Step  2.8 : l[0] and s[8]
+		mix2	r18,r19,S_08		# Step  2.9 : l[1] and s[9]
+		mix2	r20,r21,S_09		# Step 2.10 : l[2] and s[10]
+		mix2	r16,r17,S_10		# Step 2.11 : l[0] and s[11]
+		mix2	r18,r19,S_11		# Step 2.12 : l[1] and s[12]
+		mix2	r20,r21,S_12		# Step 2.13 : l[2] and s[13]
+		mix2	r16,r17,S_13		# Step 2.14 : l[0] and s[14]
+		mix2	r18,r19,S_14		# Step 2.15 : l[1] and s[15]
+		mix2	r20,r21,S_15		# Step 2.16 : l[2] and s[16]
+		mix2	r16,r17,S_16		# Step 2.17 : l[0] and s[17]
+		mix2	r18,r19,S_17		# Step 2.18 : l[1] and s[18]
+		mix2	r20,r21,S_18		# Step 2.19 : l[2] and s[19]
+		mix2	r16,r17,S_19		# Step 2.20 : l[0] and s[20]
+		mix2	r18,r19,S_20		# Step 2.21 : l[1] and s[21]
+		mix2	r20,r21,S_21		# Step 2.22 : l[2] and s[22]
+		mix2	r16,r17,S_22		# Step 2.23 : l[0] and s[23]
+		mix2	r18,r19,S_23		# Step 2.24 : l[1] and s[24]
+
+		# Terminate step 24 : Compute l[2]
+		
+		lwz		r30,S_25(r1)		# pre-load s0[25]
+		add		r20,r20,r24			# l0[2] += t0
+		add		r21,r21,r25			# l1[2] += t1
+		lwz		r31,S_25+4(r1)		# pre-load s1[25]
+		rotlw	r20,r20,r24			# b0 = l0[2] = ROTL(...)
+		rotlw	r21,r21,r25			# b1 = l1[2] = ROTL(...)
+		stw		r22,S_24(r1)		# save s0[24]
+		
+		# Step 2.25 : Compute s[25] and l[0]
+
+		add		r24,r22,r20			# t0 = a0 + b0
+		add		r25,r23,r21			# r1 = a1 + b1
+		stw		r23,S_24+4(r1)		# save s1[24]
+		add		r22,r30,r24			# s0[25] += t0
+		add		r23,r31,r25			# s1[25] += t1
+		rotlwi	r22,r22,3			# a0 = s0[25] = ROTL3(...)
+		rotlwi	r23,r23,3			# a1 = s1[25] = ROTL3(...)
+		
+		lwz		r30,S_00(r1)		# pre-load s0[0]
+		add		r24,r22,r20			# t0 = a0 + b0
+		add		r25,r23,r21			# r1 = a1 + b1
+		lwz		r31,S_00+4(r1)		# pre-load s1[0]
+		add		r16,r16,r24			# l0[0] += t0
+		add		r17,r17,r25			# l1[0] += t1
+		stw		r22,S_25(r1)		# save s0[25]
+		rotlw	r16,r16,r24			# b0 = l0[0] = ROTL(...)
+		rotlw	r17,r17,r25			# b1 = l1[0] = ROTL(...)
+		stw		r23,S_25+4(r1)		# save s1[25]
+
+	#== Pass 3 : Update s[0] ... s[25]
+	#	Also perform the round pass
+	# r26-r27 := A0, A1
+	# r28-r29 := B0,B1
+
+		# Step 3.0 : Compute s[0], l[1] and A
+		
+		add		r24,r22,r16			# t0 = a0 + b0
+		add		r25,r23,r17			# t1 = a1 + b1
+		add		r22,r30,r24			# s0[0] += t0
+		add		r23,r31,r25			# s1[0] += t1
+		lwz		r30,S_01(r1)		# pre-load s0[1]
+		rotlwi	r22,r22,3			# a0 = s0[0] = ROTL3(...)
+		rotlwi	r23,r23,3			# a1 = s1[0] = ROTL3(...)
+		lwz		r31,S_01+4(r1)		# pre-load s1[1]
+		
+		add		r24,r22,r16			# t0 = a0 + b0
+		add		r25,r23,r17			# t1 = a1 + b1
+		lwz		r27,plain_lo(r3)	# plain.lo
+		add		r18,r18,r24			# l0[1] += t0
+		add		r19,r19,r25			# l1[1] += t1
+		lwz		r29,plain_hi(r3)	# plain.hi
+		rotlw	r18,r18,r24			# b0 = l0[1] = ROTL(...)
+		add		r26,r27,r22			# A0 = plain.lo + s0[0]
+		rotlw	r19,r19,r25			# b1 = l1[1] = ROTL(...)
+		add		r27,r27,r23			# A1 = plain.lo + s1[0]
+
+		# Step 3.1 : Compute s[1], l[2] and B
+		
+		add		r24,r22,r18			# t0 = a0 + b0
+		add		r25,r23,r19			# t1 = a1 + b1
+		add		r22,r30,r24			# s0[1] += t0
+		add		r23,r31,r25			# s1[1] += t1
+		lwz		r30,S_02(r1)		# pre-load s0[2]
+		rotlwi	r22,r22,3			# a0 = s0[1] = ROTL3(...)
+		rotlwi	r23,r23,3			# a1 = s1[1] = ROTL3(...)
+		lwz		r31,S_02+4(r1)		# pre-load s1[2]
+
+		add		r24,r22,r18			# t0 = a0 + b0
+		add		r25,r23,r19			# t1 = a1 + b1
+		add		r20,r20,r24			# l0[2] += t0
+		add		r21,r21,r25			# l1[2] += t1
+		rotlw	r20,r20,r24			# b0 = l0[2] = ROTL(...)
+		add		r28,r29,r22			# B0 = plain.hi + s0[1]
+		rotlw	r21,r21,r25			# b1 = l1[2] = ROTL(...)
+		add		r29,r29,r23			# B1 = plain.hi + s1[1]
+
+
+	.macro	mix3 arg0, arg1, arg2, arg3, arg4, arg5, arg6
+					# l0[i-1], l1[i-1], l0[i], l1[i], l0[i+1], l1[i+1], S_xx
+					#    $0       $1      $2     $3      $4       $5     $6
+		
+		add		r24,r22,\arg0			# t0 = a0 + b0
+		xor		r26,r26,r28			# A0 = A0 ^ B0
+		add		r25,r23,\arg1			# t1 = a1 + b1
+		xor		r27,r27,r29			# A1 = A1 ^ B1
+		add		r22,r30,r24			# s0[j] += t0
+		rotlw	r26,r26,r28			# A0 = ROTL(A0, B0)
+		add		r23,r31,r25			# s1[j] += t1
+		lwz		r30,\arg6(r1)			# pre-load s0[j+1]
+		rotlwi	r22,r22,3			# a0 = s0[j] = ROTL3(...)
+		rotlwi	r23,r23,3			# a1 = s1[j] = ROTL3(...)
+		lwz		r31,\arg6+4(r1)		# pre-load s1[j+1]
+		rotlw	r27,r27,r29			# A1 = ROTL(A1, B1)
+
+		add		r24,r22,\arg0			# t0 = a0 + b0
+		add		r25,r23,\arg1			# t1 = a1 + b1
+		add		\arg2,\arg2,r24			# l0[i] += t0
+		add		\arg3,\arg3,r25			# l1[i] += t1
+		rotlw	\arg2,\arg2,r24			# b0 = l0[i] = ROTL(...)
+		add		r26,r26,r22			# A0 += s0[j]
+		rotlw	\arg3,\arg3,r25			# b1 = l1[i] = ROTL(...)
+		add		r27,r27,r23			# A1 += s1[j]
+
+		add		r24,r22,\arg2			# t0 = a0 + b0
+		xor		r28,r28,r26			# B0 = B0 ^ A0
+		add		r25,r23,\arg3			# t1 = a1 + b1
+		xor		r29,r29,r27			# B1 = B1 ^ A1
+		add		r22,r30,r24			# s0[j+1] += t0
+		rotlw	r28,r28,r26			# B0 = ROTL(B0, A0)
+		add		r23,r31,r25			# s1[j+1] += t1
+		lwz		r30,\arg6+8(r1)		# pre-load s0[j+2]
+		rotlwi	r22,r22,3			# a0 = s0[j+1] = ROTL3(...)
+		rotlwi	r23,r23,3			# a1 = s1[j+1] = ROTL3(...)
+		lwz		r31,\arg6+12(r1)		# pre-load s1[j+2]
+		rotlw	r29,r29,r27			# B1 = ROTL(B1, A1)
+		
+		add		r24,r22,\arg2			# t0 = a0 + b0
+		add		r25,r23,\arg3			# t1 = a1 + b1
+		add		\arg4,\arg4,r24			# l0[i+1] += t0
+		add		\arg5,\arg5,r25			# l1[i+1] += t1
+		rotlw	\arg4,\arg4,r24			# b0 = l0[i+1] = ROTL(...)
+		add		r28,r28,r22			# B0 += s0[j+1]
+		rotlw	\arg5,\arg5,r25			# b1 = l1[i+1] = ROTL(...)
+		add		r29,r29,r23			# B1 += s1[j+1]
+	.endm
+
+		mix3	r20,r21,r16,r17,r18,r19,S_03
+		mix3	r18,r19,r20,r21,r16,r17,S_05
+		mix3	r16,r17,r18,r19,r20,r21,S_07
+		mix3	r20,r21,r16,r17,r18,r19,S_09
+		mix3	r18,r19,r20,r21,r16,r17,S_11
+		mix3	r16,r17,r18,r19,r20,r21,S_13
+		mix3	r20,r21,r16,r17,r18,r19,S_15
+		mix3	r18,r19,r20,r21,r16,r17,S_17
+		mix3	r16,r17,r18,r19,r20,r21,S_19
+		mix3	r20,r21,r16,r17,r18,r19,S_21
+		mix3	r18,r19,r20,r21,r16,r17,S_23
+
+		# Step 3.24 : Compute s[24] and l[1]
+
+		add		r24,r22,r16			# t0 = a0 + b0
+		xor		r26,r26,r28			# A0 = A0 ^ B0
+		add		r25,r23,r17			# t1 = a1 + b1
+		xor		r27,r27,r29			# A1 = A1 ^ B1
+		add		r22,r30,r24			# s0[24] += t0
+		rotlw	r26,r26,r28			# A0 = ROTL(A0, B0)
+		add		r23,r31,r25			# s1[24] += t1
+		lwz		r30,S_25(r1)		# pre-load s0[25]
+		rotlwi	r22,r22,3			# a0 = s0[24] = ROTL3(...)
+		rotlwi	r23,r23,3			# a1 = s1[24] = ROTL3(...)
+		lwz		r31,S_25+4(r1)		# pre-load s1[25]
+		rotlw	r27,r27,r29			# A1 = ROTL(A1, B1)
+
+		add		r24,r22,r16			# t0 = a0 + b0
+		add		r25,r23,r17			# t1 = a1 + b1
+		add		r18,r18,r24			# l0[1] += t0
+		add		r19,r19,r25			# l1[1] += t1
+		add		r26,r26,r22			# A0 += s0[24]
+		rotlw	r18,r18,r24			# b0 = l0[1] = ROTL(...)
+		cmpl	cr0,r26,r2			# A0 == cypher.lo ?
+		add		r27,r27,r23			# A1 += s1[24]
+		rotlw	r19,r19,r25			# b1 = l1[1] = ROTL(...)
+		cmpl	cr1,r27,r2			# A1 == cypher.lo ?
+		
+		lwz		r9,12(r10)			# S[3]
+		beq		cr0,check_key0
+		beq		cr1,check_key1
+
+next_key:
+		addi	r6,r6,2
+		bdnz	inner_loop_hi
+		
+	# Increment key.mid
+	
+		srwi	r0,r6,8				# key.hi / 256
+		cmpli	cr0,r5,0
+		add		r7,r7,r0			# Increment key.mid (if key.hi overflowed)
+		clrlwi	r6,r6,24
+		cmpli	cr1,r5,0xFF
+		li		r0,0x100			# Preset inner loop count.
+		beq		cr0,exit			# iteration == 0 : Exit
+
+		bgt		cr1,set_CTR
+		mr		r0,r5				# Select inner loop count
+	
+set_CTR:
+		subf	r5,r0,r5			# Update iterations count
+		srwi	r0,r0,1				# Check 2 keys per loop
+		cmpli	cr0,r7,0			# TRUE => Increment key.lo
+		mtctr	r0					# inner loop counter
+		li		r0,Key+4
+		stwbrx	r7,r1,r0			# Store key.mid
+		bne		cr0,inner_loop_mid
+		
+
+	# Increment key.lo
+
+inc_key_lo:
+		li		r0,Key+8
+		addi	r8,r8,1
+		stwbrx	r8,r1,r0			# Store key.lo
+		b		inner_loop_lo
+	
+exit:	li		r4,RESULT_NOTHING	# Not found.
+		b		epilog
+
+
+	# Check whether key #0 matches.
+
+check_key0:							# Step 3.25 : compute s0[25]		
+		add		r24,r22,r18			# t0 = a0 + b0
+		xor		r28,r28,r26			# B0 = B0 ^ A0
+		add		r22,r30,r24			# s0[25] += t0
+		rotlw	r28,r28,r26			# B0 = ROTL(B0, A0)
+		lwz		r26,cypher_hi(r3)
+		rotlwi	r22,r22,3			# a0 = s0[25] = ROTL3(...)
+		lwz		r24,check_count(r3)
+		add		r28,r28,r22			# B0 += s0[25]
+		addi	r24,r24,1
+		cmpl	cr0,r26,r28			# B0 == cypher.hi ?
+		stw		r24,check_count(r3)
+		
+		li		r0,0				# key #0
+		addi	r24,r6,0			# key.hi
+		li		r25,check_mid
+		li		r26,check_lo
+		stw		r24,check_hi(r3)	# check.hi
+		stwbrx	r7,r25,r3			# check.mid
+		stwbrx	r8,r26,r3			# check.lo
+
+		beq		cr0,key_found
+		bne		cr1,next_key		# A1 != cypher.lo
+
+	# Check whether key #1 matches.
+	
+check_key1:							# Step 3.25 : compute s1[25]
+		add		r25,r23,r19			# t1 = a1 + b1
+		xor		r29,r29,r27			# B1 = B1 ^ A1
+		add		r23,r31,r25			# s1[25] += t1
+		rotlw	r29,r29,r27			# B1 = ROTL(B1, A1)
+		lwz		r27,cypher_hi(r3)
+		rotlwi	r23,r23,3			# a1 = s1[25] = ROTL3(...)
+		lwz		r24,check_count(r3)	
+		add		r29,r29,r23			# B1 += s1[25]
+		addi	r24,r24,1
+		cmpl	cr1,r27,r29			# B1 == cypher_hi ?
+		stw		r24,check_count(r3)
+	
+		li		r0,1				# key #1
+		addi	r24,r6,1			# key.hi
+		li		r25,check_mid
+		li		r26,check_lo
+		stw		r24,check_hi(r3)	# check.hi
+		stwbrx	r7,r25,r3			# check.mid
+		stwbrx	r8,r26,r3			# check.lo
+
+		bne		cr1,next_key
+
+	# Key found. r0 := key offset (0 or 1)
+
+key_found:
+		mfctr	r9
+		slwi	r9,r9,1
+		lwz		r10,0(r4)			# Initial iterations
+		add		r5,r5,r9
+		subf	r5,r0,r5			# r5 := remaining iterations.
+		subf	r10,r5,r10
+		stw		r10,0(r4)			# How many iterations done.
+
+		li		r4,RESULT_FOUND
+
+
+		#--------------------------------------------------------------------
+		# Epilog
+		# Restore r2, LR and GPRs from the stack frame.
+		# r4 := RESULT_FOUND or RESULT_NOTHING
+
+epilog:	
+		li		r10,L0_mid
+		li		r11,L0_lo
+		stw		r6,L0_hi(r3)		# L0_hi
+		stwbrx	r7,r10,r3			# L0_mid
+		stwbrx	r8,r11,r3			# L0_lo
+		
+		lwz		r2,saveR2(r1)		# Restore r2
+		lwz		r6,0(r1)			# Caller's SP
+		lmw		r13,-GPRSave(r6)	# Restore GPRs
+		mr		r1,r6				# Restore caller's stack pointer.
+		mr		r3,r4				# Return code
+		lwz		r0,oldLR(r6)		# LR (from caller's frame)
+		mtlr	r0
+		blr
+
+#============================================================================
+
+		.rodata
+		.align	4
+
+		
+expanded_key:					# Static expanded key table S[]
+
+		# explicitly truncate calculated values to 32 bit
+		.long	0xBF0A8B1D		# ROTL3(P)
+		.long	(P+Q) & 0xffffffff
+		.long	(P+Q*2) & 0xffffffff
+		.long	(P+Q*3) & 0xffffffff
+		.long	(P+Q*4) & 0xffffffff
+		.long	(P+Q*5) & 0xffffffff
+		.long	(P+Q*6) & 0xffffffff
+		.long	(P+Q*7) & 0xffffffff
+		.long	(P+Q*8) & 0xffffffff
+		.long	(P+Q*9) & 0xffffffff
+		.long	(P+Q*10) & 0xffffffff
+		.long	(P+Q*11) & 0xffffffff
+		.long	(P+Q*12) & 0xffffffff
+		.long	(P+Q*13) & 0xffffffff
+		.long	(P+Q*14) & 0xffffffff
+		.long	(P+Q*15) & 0xffffffff
+		.long	(P+Q*16) & 0xffffffff
+		.long	(P+Q*17) & 0xffffffff
+		.long	(P+Q*18) & 0xffffffff
+		.long	(P+Q*19) & 0xffffffff
+		.long	(P+Q*20) & 0xffffffff
+		.long	(P+Q*21) & 0xffffffff
+		.long	(P+Q*22) & 0xffffffff
+		.long	(P+Q*23) & 0xffffffff
+		.long	(P+Q*24) & 0xffffffff
+		.long	(P+Q*25) & 0xffffffff

--- a/rc5-72/ppc/r72-KKS604e.gas2.s
+++ b/rc5-72/ppc/r72-KKS604e.gas2.s
@@ -290,10 +290,9 @@ set_counter:
 		#lis		r10,(expanded_key)@ha
 		#la		r10,(expanded_key)@l(r10)
 		bl	bl_trick
-.long expanded_key
 bl_trick:
 		mflr	r10
-		lwz	r10,0(r10)
+		addi	r10,r10,expanded_key-bl_trick
 		
 
 	#---------------------------------------------------------------------
@@ -919,7 +918,8 @@ epilog:
 
 #============================================================================
 
-		.rodata
+		# keep expanded_key in .text section, so it is possible to
+		# addi	r10,r10,expanded_key-bl_trick
 		.align	4
 
 		

--- a/rc5-72/ppc/r72-KKS604e.gas2.s
+++ b/rc5-72/ppc/r72-KKS604e.gas2.s
@@ -289,7 +289,7 @@ set_counter:
 		
 		#lis		r10,(expanded_key)@ha
 		#la		r10,(expanded_key)@l(r10)
-		bl	bl_trick
+		bcl	20,31,bl_trick	# see PowerPC PEM 32b doc
 bl_trick:
 		mflr	r10
 		addi	r10,r10,expanded_key-bl_trick


### PR DESCRIPTION
make it work with OpenBSD 5.8 macppc

I guess the Position independent code is make things harder for the relocation used by ASM code like
```
lis		r10,(expanded_key)@ha
la		r10,(expanded_key)@l(r10)
```