### PR TITLE
Added support for ARM64/OpenCL (RC5-72) and ARM64 (OGR-NG & ANSI RC5-72) on macOS 11 (Apple Silicon)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ logfile*.log
 trace.out
 
 output/
+.DS_Store

--- a/common/clisync.h
+++ b/common/clisync.h
@@ -182,7 +182,7 @@
     return 1;
   }
 
-#elif (CLIENT_CPU == CPU_X86) || (CLIENT_CPU == CPU_AMD64) || (CLIENT_CPU == CPU_CUDA) || (CLIENT_CPU == CPU_ATI_STREAM) || (CLIENT_CPU == CPU_OPENCL) || ((CLIENT_CPU == CPU_ARM) && !defined(__GNUC__))
+#elif (CLIENT_CPU == CPU_X86) || (CLIENT_CPU == CPU_AMD64) || (CLIENT_CPU == CPU_CUDA) || (CLIENT_CPU == CPU_ATI_STREAM) || (CLIENT_CPU == CPU_OPENCL) && !defined(__arm64__)|| ((CLIENT_CPU == CPU_ARM) && !defined(__GNUC__))
 
   typedef volatile long fastlock_t;
 

--- a/common/clisync.h
+++ b/common/clisync.h
@@ -182,7 +182,8 @@
     return 1;
   }
 
-#elif (CLIENT_CPU == CPU_X86) || (CLIENT_CPU == CPU_AMD64) || (CLIENT_CPU == CPU_CUDA) || (CLIENT_CPU == CPU_ATI_STREAM) || (CLIENT_CPU == CPU_OPENCL) && !defined(__arm64__)|| ((CLIENT_CPU == CPU_ARM) && !defined(__GNUC__))
+#elif (CLIENT_CPU == CPU_X86) || (CLIENT_CPU == CPU_AMD64) || (CLIENT_CPU == CPU_CUDA) || (CLIENT_CPU == CPU_ATI_STREAM) || ((CLIENT_CPU == CPU_OPENCL) && !defined(__arm64__)) || \
+  ((CLIENT_CPU == CPU_ARM) && !defined(__GNUC__)) || ((CLIENT_CPU == CPU_ARM64) && !defined(__GNUC__))
 
   typedef volatile long fastlock_t;
 

--- a/common/core_r72.cpp
+++ b/common/core_r72.cpp
@@ -207,11 +207,15 @@ const char **corenames_for_contest_rc572()
       "KKS 2-pipe",
       "AnBe 1-pipe",
       "AnBe 2-pipe",
-  #elif (CLIENT_CPU == CPU_ARM64)
+  #elif (CLIENT_CPU == CPU_ARM64 && (CLIENT_OS != OS_MACOSX))
       "ANSI 4-pipe",
       "ANSI 2-pipe",
       "ANSI 1-pipe",
       "KS-ScalarFusion",
+  #elif (CLIENT_CPU == CPU_ARM64 && (CLIENT_OS == OS_MACOSX))
+      "ANSI 4-pipe",
+      "ANSI 2-pipe",
+      "ANSI 1-pipe",
   #elif (CLIENT_CPU == CPU_MIPS)
       "ANSI 4-pipe",
       "ANSI 2-pipe",
@@ -1084,7 +1088,7 @@ int selcoreSelectCore_rc572(Client *client, unsigned int threadindex,
          break;
      #endif
 
-    #if (CLIENT_CPU == CPU_ARM64)
+    #if (CLIENT_CPU == CPU_ARM64 && (CLIENT_OS != OS_MACOSX))
        case 3:
 	unit_func.gen_72 = rc5_72_unit_func_scalarfusion;
 	pipeline_count = 1;

--- a/common/cputypes.h
+++ b/common/cputypes.h
@@ -438,7 +438,7 @@
     #define HAVE_POSIX_THREADS
   #endif
 #elif defined(__APPLE__)
-  #if defined(__arm64__)
+  #if defined(__arm64__) && !defined(OPENCL)
     #define CLIENT_OS_NAME  "iOS"
     #define CLIENT_OS       OS_IOS
     #define CLIENT_CPU      CPU_ARM64

--- a/common/cputypes.h
+++ b/common/cputypes.h
@@ -441,11 +441,11 @@
   #if defined(__arm64__) && !defined(OPENCL) 
     #define CLIENT_OS_NAME  "iOS"
     #define CLIENT_OS       OS_IOS
-    #define CLIENT_CPU    CPU_ARM64
+    #define CLIENT_CPU      CPU_ARM64
   #elif defined(__arm__) || defined(ARM)
     #define CLIENT_OS_NAME  "iOS"
     #define CLIENT_OS       OS_IOS
-    #define CLIENT_CPU    CPU_ARM
+    #define CLIENT_CPU      CPU_ARM
   #else
     #define CLIENT_OS_NAME  "Mac OS X"
     #define CLIENT_OS       OS_MACOSX

--- a/common/cputypes.h
+++ b/common/cputypes.h
@@ -455,7 +455,7 @@
   #endif
   #if defined(CUDA) && (defined(__i386__) || defined(__x86_64__))
     #define CLIENT_CPU    CPU_CUDA
-  #elif defined(OPENCL) && (defined(__i386__) || defined(__x86_64__))
+  #elif defined(OPENCL) && (defined(__i386__) || defined(__x86_64__) || defined(__arm64__))
     #define CLIENT_CPU    CPU_OPENCL
   #elif defined(__ppc__) || defined(__ppc64__)
     #define CLIENT_CPU    CPU_POWERPC

--- a/common/cputypes.h
+++ b/common/cputypes.h
@@ -438,18 +438,17 @@
     #define HAVE_POSIX_THREADS
   #endif
 #elif defined(__APPLE__)
-  #if defined(__arm64__) && !defined(OPENCL) 
+  #if defined (IOS)
     #define CLIENT_OS_NAME  "iOS"
     #define CLIENT_OS       OS_IOS
-    #define CLIENT_CPU      CPU_ARM64
-  #elif defined(__arm__) || defined(ARM)
-    #define CLIENT_OS_NAME  "iOS"
-    #define CLIENT_OS       OS_IOS
-    #define CLIENT_CPU      CPU_ARM
+  #else
+  #define CLIENT_OS       OS_MACOSX
+  #if defined(__arm64__)
+    #define CLIENT_OS_NAME  "Mac OS X" // Added this incase we want to identify this as macOS 11 in the future.
   #else
     #define CLIENT_OS_NAME  "Mac OS X"
-    #define CLIENT_OS       OS_MACOSX
-  #endif
+#endif
+#endif
   #ifndef __unix__
     #define __unix__
   #endif

--- a/common/cputypes.h
+++ b/common/cputypes.h
@@ -438,14 +438,14 @@
     #define HAVE_POSIX_THREADS
   #endif
 #elif defined(__APPLE__)
-  #if defined(__arm64__) && !defined(OPENCL)
+  #if defined(__arm64__) && !defined(OPENCL) 
     #define CLIENT_OS_NAME  "iOS"
     #define CLIENT_OS       OS_IOS
-    #define CLIENT_CPU      CPU_ARM64
+    #define CLIENT_CPU    CPU_ARM64
   #elif defined(__arm__) || defined(ARM)
     #define CLIENT_OS_NAME  "iOS"
     #define CLIENT_OS       OS_IOS
-    #define CLIENT_CPU      CPU_ARM
+    #define CLIENT_CPU    CPU_ARM
   #else
     #define CLIENT_OS_NAME  "Mac OS X"
     #define CLIENT_OS       OS_MACOSX
@@ -463,6 +463,10 @@
     #define CLIENT_CPU    CPU_X86
   #elif defined(ASM_AMD64) || defined(__x86_64__) || defined(__amd64__)
     #define CLIENT_CPU    CPU_AMD64
+  #elif defined(__arm64__)
+    #define CLIENT_CPU    CPU_ARM64
+  #elif defined(__arm__)
+    #define CLIENT_CPU    CPU_ARM
   #endif
 #elif defined(__BEOS__) || defined(__be_os)
   #ifndef __unix__ /* 4.4bsd compatible or not? */

--- a/configure
+++ b/configure
@@ -1763,8 +1763,9 @@ case "$1" in
 
     *ios-arm64)              # [zebe] iOS 7+, 64-bit (Xcode >= 6 recommended)
         TARGET_plat="-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk -miphoneos-version-min=7.1 -DIPHONEOS_DEPLOYMENT_TARGET=7.1 -DTARGETED_DEVICE_FAMILY=\"1,2\" -arch arm64"
-        TARGET_CCFLAGS="$OPTS_CLANGCC -Os -DHAVE_POSIX_THREADS $TARGET_plat"
+        TARGET_CCFLAGS="$OPTS_CLANGCC -Os -DIOS -DHAVE_POSIX_THREADS $TARGET_plat"
         TARGET_LIBS="-framework CoreFoundation"
+        TARGET_AS="gcc -c $TARGET_CCFLAGS"
         TARGET_LDFLAGS="$TARGET_plat"
         TARGET_IS_CROSSCOMPILE=1
         TARGET_DOCFILES="docs/readme._ix"   #platform specific docfile
@@ -1774,13 +1775,24 @@ case "$1" in
         
     *ios-arm)              # [zebe] iOS 5+, 32-bit (Xcode >= 5 recommended)
         TARGET_plat="-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk -miphoneos-version-min=5.1 -DIPHONEOS_DEPLOYMENT_TARGET=5.1 -DTARGETED_DEVICE_FAMILY=\"1,2\" -arch armv7"
-        TARGET_CCFLAGS="$OPTS_CLANGCC -Os -DHAVE_POSIX_THREADS $TARGET_plat"
+        TARGET_CCFLAGS="$OPTS_CLANGCC -Os -DIOS -DHAVE_POSIX_THREADS $TARGET_plat"
         TARGET_LIBS="-framework CoreFoundation"
         TARGET_LDFLAGS="$TARGET_plat"
         TARGET_IS_CROSSCOMPILE=1
         TARGET_DOCFILES="docs/readme._ix"   #platform specific docfile
         TARGET_TARBALL="ios-arm"
         add_sources "ios" "generic"
+        ;;
+
+    *macosx-arm64)
+        TARGET_plat="-mmacosx-version-min=11.0 -DMACOSX_DEPLOYMENT_TARGET=11.0 -arch arm64"
+        TARGET_CCFLAGS="$OPTS_CLANGCC -DHAVE_POSIX_THREADS $TARGET_plat"
+        TARGET_AS="gcc -c $TARGET_CCFLAGS"
+        TARGET_LIBS="-framework CoreFoundation -framework IOKit"
+        TARGET_LDFLAGS="$TARGET_plat"
+        TARGET_TARBALL="macosx-arm64"
+        TARGET_DOCFILES="docs/readme._ix"
+        add_sources "macosx" "arm64"
         ;;
 
 # IA64 *****************************************************************

--- a/configure
+++ b/configure
@@ -3498,7 +3498,7 @@ case "$1" in
         TARGET_LDFLAGS="$TARGET_plat"
         TARGET_DOCFILES="docs/readme._ix docs/readme.opencl"   #platform specific docfile
         TARGET_TARBALL="macosx-arm64-opencl"
-        add_sources "macosx" "opencl" "arm64"
+        add_sources "macosx" "opencl"
         ;;
 
 ###### Unknown

--- a/configure
+++ b/configure
@@ -120,7 +120,7 @@ OGR="ogr"
 
 # select the projects to include in the client
 HAVE_RC5_72="1"
-HAVE_OGR="0"
+HAVE_OGR="1"
 HAVE_OGR_P2="0"
 
 # define these to "0" in add_sources() if you add your own list of cores + options

--- a/configure
+++ b/configure
@@ -530,9 +530,11 @@ add_sources() # $1=os, $2=arch, $3=custom
   elif [ "$2" = "arm64" ]; then
     if [ "$HAVE_RC5_72" = "1" ]; then
       DEFAULT_RC5_72="1"
-      TARGET_ADDASMS="$TARGET_ADDASMS rc5-72/arm64/r72-ks-scalarfusion.S"
-      TARGET_ADDSRCS="$TARGET_ADDSRCS $OGR_GENERAL_SRCS rc5-72/arm64/r72-ks-scalarfusion.cpp"
-    fi # HAVE_RC5_72
+      if ["$1" -ne "macosx"]; then
+        TARGET_ADDASMS="$TARGET_ADDASMS rc5-72/arm64/r72-ks-scalarfusion.S"
+        TARGET_ADDSRCS="$TARGET_ADDSRCS $OGR_GENERAL_SRCS rc5-72/arm64/r72-ks-scalarfusion.cpp"
+      fi #if OSX
+    fi # HAVE_RC5_7
     
     if [ "$HAVE_OGR" = "1" ]; then
       DEFAULT_OGRNG="0"     # don't add the 32-bit ansi core

--- a/configure
+++ b/configure
@@ -120,7 +120,7 @@ OGR="ogr"
 
 # select the projects to include in the client
 HAVE_RC5_72="1"
-HAVE_OGR="1"
+HAVE_OGR="0"
 HAVE_OGR_P2="0"
 
 # define these to "0" in add_sources() if you add your own list of cores + options
@@ -3489,6 +3489,16 @@ case "$1" in
         TARGET_DOCFILES="docs/readme._ix docs/readme.opencl"   #platform specific docfile
         TARGET_TARBALL="macosx-x86-opencl"
         add_sources "macosx" "opencl"
+        ;;
+
+     *macosx-arm64-opencl)       # macOS 11 64-bit, Darwin
+        TARGET_plat="-mmacosx-version-min=11.0 -DMACOSX_DEPLOYMENT_TARGET=11.0 -arch arm64"
+        TARGET_CCFLAGS="$OPTS_CLANGCC -DOPENCL -DDYN_TIMESLICE $TARGET_plat"
+        TARGET_LIBS="-framework IOKit -framework CoreFoundation -framework OpenCL"
+        TARGET_LDFLAGS="$TARGET_plat"
+        TARGET_DOCFILES="docs/readme._ix docs/readme.opencl"   #platform specific docfile
+        TARGET_TARBALL="macosx-arm64-opencl"
+        add_sources "macosx" "opencl" "arm64"
         ;;
 
 ###### Unknown

--- a/plat/macosx/temperature.cpp
+++ b/plat/macosx/temperature.cpp
@@ -246,7 +246,10 @@ static UInt32 _SMCread(UInt32 key, io_connect_t connection)
   smc_input.key = key;
   smc_input.cmd = SMC_READ_KEYINFO;
 
-#if defined(__x86_64__)
+#if defined(__x86_64__) 
+  if (kIOReturnSuccess == IOConnectCallStructMethod(connection, 2, 
+    &smc_input, input_size, &smc_output, &output_size)) {
+#elif defined(__arm64__)
   if (kIOReturnSuccess == IOConnectCallStructMethod(connection, 2, 
     &smc_input, input_size, &smc_output, &output_size)) {
 #else
@@ -261,6 +264,9 @@ static UInt32 _SMCread(UInt32 key, io_connect_t connection)
       return 0;         // Unknown key.
 
 #if defined(__x86_64__)
+    if (kIOReturnSuccess == IOConnectCallStructMethod(connection, 2, 
+      &smc_input, input_size, &smc_output, &output_size)) {
+#elif defined(__arm64__)
     if (kIOReturnSuccess == IOConnectCallStructMethod(connection, 2, 
       &smc_input, input_size, &smc_output, &output_size)) {
 #else

--- a/plat/macosx/temperature.cpp
+++ b/plat/macosx/temperature.cpp
@@ -246,10 +246,7 @@ static UInt32 _SMCread(UInt32 key, io_connect_t connection)
   smc_input.key = key;
   smc_input.cmd = SMC_READ_KEYINFO;
 
-#if defined(__x86_64__) 
-  if (kIOReturnSuccess == IOConnectCallStructMethod(connection, 2, 
-    &smc_input, input_size, &smc_output, &output_size)) {
-#elif defined(__arm64__)
+#if defined(__x86_64__) || defined(__arm64__)
   if (kIOReturnSuccess == IOConnectCallStructMethod(connection, 2, 
     &smc_input, input_size, &smc_output, &output_size)) {
 #else
@@ -263,10 +260,7 @@ static UInt32 _SMCread(UInt32 key, io_connect_t connection)
     if (smc_input.size == 0)
       return 0;         // Unknown key.
 
-#if defined(__x86_64__)
-    if (kIOReturnSuccess == IOConnectCallStructMethod(connection, 2, 
-      &smc_input, input_size, &smc_output, &output_size)) {
-#elif defined(__arm64__)
+#if defined(__x86_64__) || defined(__arm64__)
     if (kIOReturnSuccess == IOConnectCallStructMethod(connection, 2, 
       &smc_input, input_size, &smc_output, &output_size)) {
 #else

--- a/rc5-72/arm64/r72-ks-scalarfusion.S
+++ b/rc5-72/arm64/r72-ks-scalarfusion.S
@@ -3,8 +3,13 @@
 // Returns completed A and B, needs C++ support file for final checks
 
 .text
+#if defined(__APPLE__)
+.globl _scalarFusionEntry
+_scalarFusionEntry:
+#else
 .globl scalarFusionEntry
 scalarFusionEntry:
+#endif
   // push fp and lr
   stp x29, x30, [sp, #-16]!
 


### PR DESCRIPTION
### Added support for Apple Silicon ARM64/OPENCL (RC5-72).

**ARM64 Native (this fork)**
[Nov 28 10:37:15 UTC] RC5-72 benchmark summary :
                      Default core : #-1 (undefined) 0 keys/sec
                      Fastest core : #1 (CL 1-pipe) 952,068,808 keys/sec

**Existing AMD64 under Rosetta 2**
[Nov 28 10:39:10 UTC] RC5-72 benchmark summary :
                      Default core : #-1 (undefined) 0 keys/sec
                      Fastest core : #1 (CL 1-pipe) 881,571,409 keys/sec

### Added support for Apple Silicon ARM64 (OGR-NG).

**ARM64 Native (this fork)**
[Nov 30 13:12:32 UTC] OGR-NG: Benchmark for core #0 (FLEGE 2.0)                                                                              
                      0.00:00:16.98 [109,275,989 nodes/sec]

**Existing AMD64 under Rosetta 2**
[Nov 30 13:13:43 UTC] OGR-NG benchmark summary :
                      Default core : #2 (cj-asm-sse2) 60,832,450 nodes/sec
                      Fastest core : #1 (cj-asm-generic) 88,987,193 nodes/sec

### Added support for Apple Silicon ARM64 (RC5-72 ANSI). 
Slower than AMD64 under Rosetta 2 as ScalarFusion Core not functional on Apple ARM64 at this time.

**ARM64 Native (this fork)**
[Nov 30 13:15:16 UTC] RC5-72 benchmark summary :
                      Default core : #-1 (undefined) 0 keys/sec
                      Fastest core : #0 (ANSI 4-pipe) 7,213,400 keys/sec

**Existing AMD64 under Rosetta 2**
[Nov 30 13:18:03 UTC] RC5-72 benchmark summary :
                      Default core : #3 (GO 2-pipe d) 11,192,248 keys/sec
                      Fastest core : #1 (KBE-64 3-pipe) 11,864,297 keys/sec

Notes:
- Confirmed it compiles using Clang 12.
Apple clang version 12.0.0 (clang-1200.0.32.27)
Target: arm64-apple-darwin20.1.0

- Confirmed all tests passed using './dnetc -test'

- Updated temperature.cpp to allow ARM64 but have not confirmed temperature can be read on Apple Silicon.

Still to do:
- Get ARM64 ScalarFusion functional on MacOS.
- Get Temperature reading on Apple Silicon.
- CPUINFO can not currently be read by ARM64 client.