### PR TITLE
Update reference spec and increase msgbuffer size so log message are …

### DIFF
--- a/common/logstuff.cpp
+++ b/common/logstuff.cpp
@@ -493,7 +493,7 @@ static void InternalLogMail( const char *msgbuffer, unsigned int msglen, int /*f
 // a (va_list *) instead to avoid this problem
 void LogWithPointer( int loggingTo, const char *format, va_list *arglist )
 {
-  char msgbuffer[1024]; //min 1024!!, but also think of other OSs stack!!
+  char msgbuffer[32000]; //min 1024!!, but also think of other OSs stack!!
   unsigned int msglen = 0, sel;
   char *buffptr, *obuffptr;
   int old_loggingTo = loggingTo;

--- a/rc5-72/opencl/ocl_common.cpp
+++ b/rc5-72/opencl/ocl_common.cpp
@@ -240,7 +240,7 @@ bool BuildCLProgram(ocl_context_t *cont, const char* programText, const char *ke
   if (status == CL_SUCCESS)
   {
     //status = clBuildProgram(cont->program, 1, &cont->deviceID, NULL, NULL, NULL);
-    status = clBuildProgram(cont->program, 1, &cont->deviceID, "-cl-std=CL1.1", NULL, NULL);
+    status = clBuildProgram(cont->program, 1, &cont->deviceID, "-cl-std=CL1.2", NULL, NULL);
   }
   if (ocl_diagnose(status, "building cl program", cont) != CL_SUCCESS)
   {


### PR DESCRIPTION
…displayed

Newer Intel GPUs fail tests and run if the refrence in clBuildProgram is "-cl-std=CL1.1" set it to "-cl-std=CL1.2".

msgbuffer is to small to display opencl build errors.