### PR TITLE
Fix a crash while writing a long string to the log

### DIFF
--- a/common/logstuff.h
+++ b/common/logstuff.h
@@ -50,6 +50,9 @@ extern void LogScreenRaw( const char *format, ... ) __CHKFMT_PRINTF;
 //Log to mail+file+screen. No adjustments.
 extern void LogRaw( const char *format, ... ) __CHKFMT_PRINTF;
 
+//Log to mail+file+screen. No adjustments. Supports very long strings but not formatting.
+extern void LogRawString( const char *str );
+
 //Log to LOGTO_* flags (RAW implies screen)
 extern void LogTo( int towhat, const char *format, ... ) __CHKFMT_LOGTO;
 


### PR DESCRIPTION
Corresponding code is improved to not overrun a buffer.
Added an API to write long strings to the log without trimming them.